### PR TITLE
Protocol v1.0.0 - move loan duration config to borrower

### DIFF
--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -42,7 +42,7 @@ contract LendingMarket is
     /// @notice Thrown when the loan does not exist
     error LoanNotExist();
 
-    /// @notice Thrown when the loan does not exist
+    /// @notice Thrown when the loan does not frozen
     error LoanNotFrozen();
 
     /// @notice Thrown when the loan is already repaid

--- a/src/interfaces/ICreditLineConfigurable.sol
+++ b/src/interfaces/ICreditLineConfigurable.sol
@@ -48,8 +48,10 @@ interface ICreditLineConfigurable {
     struct CreditLineConfig {
         /// @notice The duration of the loan period determined in seconds
         uint256 periodInSeconds;
-        /// @notice The total duration of the loan determined in periods
-        uint256 durationInPeriods;
+        /// @notice The minimum duration of the loan determined in periods
+        uint256 minDurationInPeriods;
+        /// @notice The maximum duration of the loan determined in periods
+        uint256 maxDurationInPeriods;
         /// @notice The minimum amount the borrower can take as a loan
         uint256 minBorrowAmount;
         /// @notice The maximum amount the borrower can take as a loan
@@ -72,6 +74,8 @@ interface ICreditLineConfigurable {
 
     /// @notice A struct that defines borrower configuration
     struct BorrowerConfig {
+        /// @notice The total duration of the loan determined in periods
+        uint256 durationInPeriods;
         /// @notice The expiration date of the borrower configuration
         uint256 expiration;
         /// @notice The minimum amount the borrower can take as a loan

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -854,10 +854,12 @@ contract LendingMarketTest is Test, Config {
     function test_updateLoanDuration() public {
         configureMarket();
         uint256 loanId = createActiveLoan(false);
-
         Loan.State memory loan = market.getLoan(loanId);
+
         uint256 oldDurationInPeriods = loan.durationInPeriods;
         uint256 newDurationInPeriods = oldDurationInPeriods + 5;
+
+        assertEq(oldDurationInPeriods, INIT_BORROWER_DURATION_IN_PERIODS);
 
         vm.prank(LENDER_1);
         vm.expectEmit(true, true, true, true, address(market));

--- a/test/base/Config.sol
+++ b/test/base/Config.sol
@@ -81,7 +81,8 @@ contract Config {
     function initCreditLineConfig() public pure returns (ICreditLineConfigurable.CreditLineConfig memory) {
         return ICreditLineConfigurable.CreditLineConfig({
             periodInSeconds: INIT_CREDIT_LINE_PERIOD_IN_SECONDS,
-            durationInPeriods: INIT_CREDIT_LINE_DURATION_IN_PERIODS,
+            minDurationInPeriods: INIT_CREDIT_LINE_MIN_DURATION_IN_PERIODS,
+            maxDurationInPeriods: INIT_CREDIT_LINE_MAX_DURATION_IN_PERIODS,
             minBorrowAmount: INIT_CREDIT_LINE_MIN_BORROW_AMOUNT,
             maxBorrowAmount: INIT_CREDIT_LINE_MAX_BORROW_AMOUNT,
             interestRateFactor: INIT_CREDIT_LINE_INTEREST_RATE_FACTOR,
@@ -100,6 +101,7 @@ contract Config {
         returns (ICreditLineConfigurable.BorrowerConfig memory)
     {
         return ICreditLineConfigurable.BorrowerConfig({
+            durationInPeriods: INIT_BORROWER_DURATION_IN_PERIODS,
             expiration: blockTimestamp + INIT_BORROWER_DURATION,
             minBorrowAmount: INIT_BORROWER_MIN_BORROW_AMOUNT,
             maxBorrowAmount: INIT_BORROWER_MAX_BORROW_AMOUNT,
@@ -147,7 +149,7 @@ contract Config {
         return Loan.Terms({
             token: token,
             periodInSeconds: creditLineConfig.periodInSeconds,
-            durationInPeriods: creditLineConfig.durationInPeriods,
+            durationInPeriods: borrowerConfig.durationInPeriods,
             interestRateFactor: creditLineConfig.interestRateFactor,
             interestRatePrimary: borrowerConfig.interestRatePrimary,
             interestRateSecondary: borrowerConfig.interestRateSecondary,


### PR DESCRIPTION
## Description

There is moving `durationInPeriods` from CreditLineConfig to BorrowerConfig

## Changes to Existing Functionality

- Moved `durationInPeriods` from CreditLineConfig to BorrowerConfig.
- Added `minDurationInPeriods` and `maxDurationInPeriods` to CreditLineConfig for limitation borrower `durationInPeriods`.

## Tests and coverage

The new functionality was fully covered by tests.