### PR TITLE
Add loan revocation possibility and change the liquidity pool logic

### DIFF
--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -301,12 +301,7 @@ contract LendingMarket is
         });
 
         ILiquidityPool(liquidityPool).onBeforeLoanTaken(id, creditLine);
-
         IERC20(terms.token).safeTransferFrom(liquidityPool, msg.sender, borrowAmount);
-        if (terms.addonAmount != 0) {
-            IERC20(terms.token).safeTransferFrom(liquidityPool, terms.addonRecipient, terms.addonAmount);
-        }
-
         ILiquidityPool(liquidityPool).onAfterLoanTaken(id, creditLine);
 
         emit LoanTaken(id, msg.sender, totalBorrowAmount, terms.durationInPeriods);

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -75,8 +75,11 @@ contract LendingMarket is
     /// @dev Thrown when loan auto repayment is not allowed.
     error AutoRepaymentNotAllowed();
 
-    /// @dev Thrown when loan revocation is not allowed.
-    error RevocationNotAllowed();
+    /// @dev Thrown when the revocation period has passed.
+    error RevocationPeriodHasPassed();
+
+    /// @dev Thrown when loan revocation is prohibited.
+    error RevocationIsProhibited();
 
     // -------------------------------------------- //
     //  Modifiers                                   //
@@ -361,13 +364,13 @@ contract LendingMarket is
         Loan.State storage loan = _loans[loanId];
 
         if (loan.startTimestamp != loan.trackedTimestamp) {
-            revert RevocationNotAllowed();
+            revert RevocationIsProhibited();
         }
 
         uint256 currentPeriodIndex = _periodIndex(_blockTimestamp(loanId), loan.periodInSeconds);
         uint256 startPeriodIndex = _periodIndex(loan.startTimestamp, loan.periodInSeconds);
         if (loan.revocationPeriods <= currentPeriodIndex - startPeriodIndex ) {
-            revert RevocationNotAllowed();
+            revert RevocationPeriodHasPassed();
         }
 
         loan.trackedBorrowBalance = 0;

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -295,7 +295,8 @@ contract LendingMarket is
             trackedBorrowBalance: totalBorrowAmount,
             trackedTimestamp: blockTimestamp,
             freezeTimestamp: 0,
-            autoRepayment: terms.autoRepayment
+            autoRepayment: terms.autoRepayment,
+            revokePeriods: terms.revokePeriods
         });
 
         ILiquidityPool(liquidityPool).onBeforeLoanTaken(id, creditLine);

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -75,8 +75,8 @@ contract LendingMarket is
     /// @dev Thrown when loan auto repayment is not allowed.
     error AutoRepaymentNotAllowed();
 
-    /// @dev Thrown when loan revoke is not allowed.
-    error RevokeNotAllowed();
+    /// @dev Thrown when loan revocation is not allowed.
+    error RevocationNotAllowed();
 
     // -------------------------------------------- //
     //  Modifiers                                   //
@@ -299,7 +299,7 @@ contract LendingMarket is
             trackedTimestamp: blockTimestamp,
             freezeTimestamp: 0,
             autoRepayment: terms.autoRepayment,
-            revokePeriods: terms.revokePeriods,
+            revocationPeriods: terms.revocationPeriods,
             addonAmount: terms.addonAmount
         });
 
@@ -361,20 +361,20 @@ contract LendingMarket is
         Loan.State storage loan = _loans[loanId];
 
         if (loan.startTimestamp != loan.trackedTimestamp) {
-            revert RevokeNotAllowed();
+            revert RevocationNotAllowed();
         }
 
         uint256 currentPeriodIndex = _periodIndex(_blockTimestamp(loanId), loan.periodInSeconds);
         uint256 startPeriodIndex = _periodIndex(loan.startTimestamp, loan.periodInSeconds);
-        if (loan.revokePeriods <= currentPeriodIndex - startPeriodIndex ) {
-            revert RevokeNotAllowed();
+        if (loan.revocationPeriods <= currentPeriodIndex - startPeriodIndex ) {
+            revert RevocationNotAllowed();
         }
 
         loan.trackedBorrowBalance = 0;
 
-        ILiquidityPool(loan.treasury).onBeforeLoanRevoke(loanId);
+        ILiquidityPool(loan.treasury).onBeforeLoanRevocation(loanId);
         IERC20(loan.token).transferFrom(loan.borrower, loan.treasury, loan.initialBorrowAmount - loan.addonAmount);
-        ILiquidityPool(loan.treasury).onAfterLoanRevoke(loanId);
+        ILiquidityPool(loan.treasury).onAfterLoanRevocation(loanId);
 
         emit LoanRevoked(loanId);
     }

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -296,7 +296,8 @@ contract LendingMarket is
             trackedTimestamp: blockTimestamp,
             freezeTimestamp: 0,
             autoRepayment: terms.autoRepayment,
-            revokePeriods: terms.revokePeriods
+            revokePeriods: terms.revokePeriods,
+            addonAmount: terms.addonAmount
         });
 
         ILiquidityPool(liquidityPool).onBeforeLoanTaken(id, creditLine);

--- a/src/common/interfaces/ICreditLineConfigurable.sol
+++ b/src/common/interfaces/ICreditLineConfigurable.sol
@@ -46,8 +46,8 @@ interface ICreditLineConfigurable is ICreditLine {
         uint32 maxAddonFixedRate;        // The maximum fixed rate for the loan addon calculation.
         uint32 minAddonPeriodRate;       // The minimum period rate for the loan addon calculation.
         uint32 maxAddonPeriodRate;       // The maximum period rate for the loan addon calculation.
-        uint16 minRevokePeriods;         // The minimum number of periods during which the loan can be revoked.
-        uint16 maxRevokePeriods;         // The maximum number of periods during which the loan can be revoked.
+        uint16 minRevocationPeriods;     // The minimum number of periods during which the loan can be revoked.
+        uint16 maxRevocationPeriods;     // The maximum number of periods during which the loan can be revoked.
     }
 
     /// @dev A struct that defines borrower configuration.
@@ -66,7 +66,7 @@ interface ICreditLineConfigurable is ICreditLine {
         BorrowPolicy borrowPolicy;        // The borrow policy to be applied to the borrower.
         bool autoRepayment;               // Whether the loan can be repaid automatically.
         uint32 expiration;                // The expiration date of the configuration.
-        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
+        uint16 revocationPeriods;         // The number of periods during which the loan can be revoked.
     }
 
     // -------------------------------------------- //

--- a/src/common/interfaces/ICreditLineConfigurable.sol
+++ b/src/common/interfaces/ICreditLineConfigurable.sol
@@ -48,6 +48,8 @@ interface ICreditLineConfigurable is ICreditLine {
         // Slot 4
         uint32 minAddonPeriodRate;       // The minimum period rate for the loan addon calculation.
         uint32 maxAddonPeriodRate;       // The maximum period rate for the loan addon calculation.
+        uint16 minRevokePeriods;         // The minimum number of periods during which the loan can be revoked.
+        uint16 maxRevokePeriods;         // The maximum number of periods during which the loan can be revoked.
     }
 
     /// @dev A struct that defines borrower configuration.
@@ -66,6 +68,7 @@ interface ICreditLineConfigurable is ICreditLine {
         BorrowPolicy borrowPolicy;        // The borrow policy to be applied to the borrower.
         bool autoRepayment;               // Whether the loan can be repaid automatically.
         uint32 expiration;                // The expiration date of the configuration.
+        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
     }
 
     // -------------------------------------------- //

--- a/src/common/interfaces/ICreditLineConfigurable.sol
+++ b/src/common/interfaces/ICreditLineConfigurable.sol
@@ -42,10 +42,8 @@ interface ICreditLineConfigurable is ICreditLine {
         uint32 maxInterestRateSecondary; // The maximum secondary interest rate to be applied to the loan.
         // Slot 3
         uint32 interestRateFactor;       // The interest rate factor used for interest calculation.
-        address addonRecipient;          // The address of the loan addon recipient (extra charges or fees).
         uint32 minAddonFixedRate;        // The minimum fixed rate for the loan addon calculation.
         uint32 maxAddonFixedRate;        // The maximum fixed rate for the loan addon calculation.
-        // Slot 4
         uint32 minAddonPeriodRate;       // The minimum period rate for the loan addon calculation.
         uint32 maxAddonPeriodRate;       // The maximum period rate for the loan addon calculation.
         uint16 minRevokePeriods;         // The minimum number of periods during which the loan can be revoked.

--- a/src/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/src/common/interfaces/ILiquidityPoolAccountable.sol
@@ -34,9 +34,9 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
 
     /// @dev Emitted when tokens are withdrawn from the liquidity pool.
     /// @param creditLine The address of the credit line.
-    /// @param borrowable The amount of tokens withdrawn from the borrowable balance.
-    /// @param addons The amount of tokens withdrawn from the addons balance.
-    event Withdrawal(address indexed creditLine, uint256 borrowable, uint256 addons);
+    /// @param borrowableAmount The amount of tokens withdrawn from the borrowable balance.
+    /// @param addonAmount The amount of tokens withdrawn from the addons balance.
+    event Withdrawal(address indexed creditLine, uint256 borrowableAmount, uint256 addonAmount);
 
     /// @dev Emitted when tokens are rescued from the liquidity pool.
     /// @param token The address of the token rescued.
@@ -63,9 +63,9 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
 
     /// @dev Withdraws tokens from the liquidity pool.
     /// @param creditLine The address of the credit line.
-    /// @param borrowable The amount of tokens to withdraw from the borrowable balance.
-    /// @param addons The amount of tokens to withdraw from the addons balance.
-    function withdraw(address creditLine, uint256 borrowable, uint256 addons) external;
+    /// @param borrowableAmount The amount of tokens to withdraw from the borrowable balance.
+    /// @param addonAmount The amount of tokens to withdraw from the addons balance.
+    function withdraw(address creditLine, uint256 borrowableAmount, uint256 addonAmount) external;
 
     /// @dev Rescues tokens from the liquidity pool.
     /// @param token The address of the token to rescue.

--- a/src/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/src/common/interfaces/ILiquidityPoolAccountable.sol
@@ -9,6 +9,16 @@ import "./core/ILiquidityPool.sol";
 /// @dev Defines the accountable liquidity pool contract functions and events.
 interface ILiquidityPoolAccountable is ILiquidityPool {
     // -------------------------------------------- //
+    //  Structs and enums                           //
+    // -------------------------------------------- //
+
+    /// @dev A struct that defines the credit line balance.
+    struct CreditLineBalance {
+        uint128 borrowable; // The amount of tokens that can be borrowed.
+        uint128 addons;     // The amount of tokens that are locked as addons.
+    }
+
+    // -------------------------------------------- //
     //  Events                                      //
     // -------------------------------------------- //
 
@@ -23,9 +33,15 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     event Deposit(address indexed creditLine, uint256 amount);
 
     /// @dev Emitted when tokens are withdrawn from the liquidity pool.
-    /// @param tokenSource The address of the token source.
-    /// @param amount The amount of tokens withdrawn.
-    event Withdrawal(address indexed tokenSource, uint256 amount);
+    /// @param creditLine The address of the credit line.
+    /// @param borrowable The amount of tokens withdrawn from the borrowable balance.
+    /// @param addons The amount of tokens withdrawn from the addons balance.
+    event Withdrawal(address indexed creditLine, uint256 borrowable, uint256 addons);
+
+    /// @dev Emitted when tokens are rescued from the liquidity pool.
+    /// @param token The address of the token rescued.
+    /// @param amount The amount of tokens rescued.
+    event Rescue(address indexed token, uint256 amount);
 
     /// @dev Emitted when loan auto repayment was initiated.
     /// @param numberOfLoans The number of loans repaid.
@@ -46,19 +62,25 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     function deposit(address creditLine, uint256 amount) external;
 
     /// @dev Withdraws tokens from the liquidity pool.
-    /// @param tokenSource The address of the token source.
-    /// @param amount The amount of tokens to withdraw.
-    function withdraw(address tokenSource, uint256 amount) external;
+    /// @param creditLine The address of the credit line.
+    /// @param borrowable The amount of tokens to withdraw from the borrowable balance.
+    /// @param addons The amount of tokens to withdraw from the addons balance.
+    function withdraw(address creditLine, uint256 borrowable, uint256 addons) external;
+
+    /// @dev Rescues tokens from the liquidity pool.
+    /// @param token The address of the token to rescue.
+    /// @param amount The amount of tokens to rescue.
+    function rescue(address token, uint256 amount) external;
 
     /// @dev Executes auto repayment of loans in the batch mode.
     /// @param loanIds The unique identifiers of the loans to repay.
     /// @param amounts The payment amounts that correspond with given loan ids.
     function autoRepay(uint256[] memory loanIds, uint256[] memory amounts) external;
 
-    /// @dev Retrieves the token balance of a given token source.
-    /// @param tokenSource The address of the token source.
+    /// @dev Retrieves the token balance of the credit line.
+    /// @param creditLine The address of the credit line.
     /// @return The token balance of the token source.
-    function getTokenBalance(address tokenSource) external view returns (uint256);
+    function getCreditLineBalance(address creditLine) external view returns (CreditLineBalance memory);
 
     /// @dev Retrieves the credit line associated with a loan.
     /// @param loanId The unique identifier of the loan.

--- a/src/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/src/common/interfaces/ILiquidityPoolAccountable.sol
@@ -14,8 +14,8 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
 
     /// @dev A struct that defines the credit line balance.
     struct CreditLineBalance {
-        uint128 borrowable; // The amount of tokens that can be borrowed.
-        uint128 addons;     // The amount of tokens that are locked as addons.
+        uint64 borrowable; // The amount of tokens that can be borrowed.
+        uint64 addons;     // The amount of tokens that are locked as addons.
     }
 
     // -------------------------------------------- //

--- a/src/common/interfaces/core/ILendingMarket.sol
+++ b/src/common/interfaces/core/ILendingMarket.sol
@@ -73,6 +73,10 @@ interface ILendingMarket {
         uint256 outstandingBalance
     );
 
+    /// @dev Emitted when a loan is revoked.
+    /// @param loanId The unique identifier of the loan.
+    event LoanRevoked(uint256 indexed loanId);
+
     /// @dev Emitted when a loan is frozen.
     /// @param loanId The unique identifier of the loan.
     event LoanFrozen(uint256 indexed loanId);
@@ -150,6 +154,10 @@ interface ILendingMarket {
     /// @param loanId The unique identifier of the loan to repay.
     /// @param repayAmount The amount to repay or `type(uint256).max` to repay the remaining balance of the loan.
     function repayLoan(uint256 loanId, uint256 repayAmount) external;
+
+    /// @dev Revokes a loan.
+    /// @param loanId The unique identifier of the loan to revoke.
+    function revokeLoan(uint256 loanId) external;
 
     // -------------------------------------------- //
     //  Lender functions                            //

--- a/src/common/interfaces/core/ILiquidityPool.sol
+++ b/src/common/interfaces/core/ILiquidityPool.sol
@@ -30,13 +30,13 @@ interface ILiquidityPool {
     /// @param repayAmount The amount of tokens that was repaid.
     function onAfterLoanPayment(uint256 loanId, uint256 repayAmount) external returns (bool);
 
-    /// @dev A hook that is triggered by the associated market before a loan is revoked.
+    /// @dev A hook that is triggered by the associated market before the loan revocation.
     /// @param loanId The unique identifier of the loan being revoked.
-    function onBeforeLoanRevoke(uint256 loanId) external returns (bool);
+    function onBeforeLoanRevocation(uint256 loanId) external returns (bool);
 
-    /// @dev A hook that is triggered by the associated market after a loan is revoked.
+    /// @dev A hook that is triggered by the associated market after the loan revocation.
     /// @param loanId The unique identifier of the loan being revoked.
-    function onAfterLoanRevoke(uint256 loanId) external returns (bool);
+    function onAfterLoanRevocation(uint256 loanId) external returns (bool);
 
     /// @dev Returns the address of the associated lending market.
     function market() external view returns (address);

--- a/src/common/interfaces/core/ILiquidityPool.sol
+++ b/src/common/interfaces/core/ILiquidityPool.sol
@@ -30,6 +30,14 @@ interface ILiquidityPool {
     /// @param repayAmount The amount of tokens that was repaid.
     function onAfterLoanPayment(uint256 loanId, uint256 repayAmount) external returns (bool);
 
+    /// @dev A hook that is triggered by the associated market before a loan is revoked.
+    /// @param loanId The unique identifier of the loan being revoked.
+    function onBeforeLoanRevoke(uint256 loanId) external returns (bool);
+
+    /// @dev A hook that is triggered by the associated market after a loan is revoked.
+    /// @param loanId The unique identifier of the loan being revoked.
+    function onAfterLoanRevoke(uint256 loanId) external returns (bool);
+
     /// @dev Returns the address of the associated lending market.
     function market() external view returns (address);
 

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -48,7 +48,6 @@ library Loan {
         bool autoRepayment;               // The flag that indicates whether the loan can be repaid automatically.
         uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
         // Slot 3
-        address addonRecipient;           // The address of the loan addon recipient (extra charges or fees).
         uint64 addonAmount;               // The amount of the loan addon (extra charges or fees).
     }
 

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -25,7 +25,7 @@ library Loan {
         uint32 durationInPeriods;         // The total duration of the loan determined by the number of periods.
         Interest.Formula interestFormula; // The formula used for interest calculation on the loan.
         bool autoRepayment;               // The flag that indicates whether the loan can be repaid automatically.
-        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
+        uint16 revocationPeriods;         // The number of periods during which the loan can be revoked.
         // Slot 4
         uint64 trackedBorrowBalance;      // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;          // The timestamp when the loan was last paid or its balance was updated.
@@ -46,7 +46,7 @@ library Loan {
         uint32 durationInPeriods;         // The total duration of the loan determined by the number of periods.
         Interest.Formula interestFormula; // The formula to be used for interest calculation on the loan.
         bool autoRepayment;               // The flag that indicates whether the loan can be repaid automatically.
-        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
+        uint16 revocationPeriods;         // The number of periods during which the loan can be revoked.
         // Slot 3
         uint64 addonAmount;               // The amount of the loan addon (extra charges or fees).
     }

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -30,6 +30,7 @@ library Loan {
         uint64 trackedBorrowBalance;      // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;          // The timestamp when the loan was last paid or its balance was updated.
         uint32 freezeTimestamp;           // The timestamp when the loan was frozen. Zero value for unfrozen loans.
+        uint64 addonAmount;               // The amount of the loan addon (extra charges or fees).
     }
 
     /// @dev A struct that defines the terms of the loan.

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -25,6 +25,7 @@ library Loan {
         uint32 durationInPeriods;         // The total duration of the loan determined by the number of periods.
         Interest.Formula interestFormula; // The formula used for interest calculation on the loan.
         bool autoRepayment;               // The flag that indicates whether the loan can be repaid automatically.
+        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
         // Slot 4
         uint64 trackedBorrowBalance;      // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;          // The timestamp when the loan was last paid or its balance was updated.
@@ -44,6 +45,7 @@ library Loan {
         uint32 durationInPeriods;         // The total duration of the loan determined by the number of periods.
         Interest.Formula interestFormula; // The formula to be used for interest calculation on the loan.
         bool autoRepayment;               // The flag that indicates whether the loan can be repaid automatically.
+        uint16 revokePeriods;             // The number of periods during which the loan can be revoked.
         // Slot 3
         address addonRecipient;           // The address of the loan addon recipient (extra charges or fees).
         uint64 addonAmount;               // The amount of the loan addon (extra charges or fees).

--- a/src/common/libraries/SafeCast.sol
+++ b/src/common/libraries/SafeCast.sol
@@ -9,6 +9,21 @@ library SafeCast {
     /// @dev Value doesn't fit in an uint of `bits` size.
     error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
 
+    /// @dev Returns the downcasted uint128 from uint256, reverting on
+    /// overflow (when the input is greater than largest uint128).
+    ///
+    /// Counterpart to Solidity's `uint128` operator.
+    ///
+    /// Requirements:
+    ///
+    /// - input must fit into 128 bits
+    function toUint128(uint256 value) internal pure returns (uint128) {
+        if (value > type(uint128).max) {
+            revert SafeCastOverflowedUintDowncast(128, value);
+        }
+        return uint128(value);
+    }
+
     /// @dev Returns the downcasted uint64 from uint256, reverting on
     /// overflow (when the input is greater than largest uint64).
     ///

--- a/src/common/libraries/SafeCast.sol
+++ b/src/common/libraries/SafeCast.sol
@@ -9,21 +9,6 @@ library SafeCast {
     /// @dev Value doesn't fit in an uint of `bits` size.
     error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value);
 
-    /// @dev Returns the downcasted uint128 from uint256, reverting on
-    /// overflow (when the input is greater than largest uint128).
-    ///
-    /// Counterpart to Solidity's `uint128` operator.
-    ///
-    /// Requirements:
-    ///
-    /// - input must fit into 128 bits
-    function toUint128(uint256 value) internal pure returns (uint128) {
-        if (value > type(uint128).max) {
-            revert SafeCastOverflowedUintDowncast(128, value);
-        }
-        return uint128(value);
-    }
-
     /// @dev Returns the downcasted uint64 from uint256, reverting on
     /// overflow (when the input is greater than largest uint64).
     ///

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -174,6 +174,9 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
         if (config.minAddonPeriodRate > config.maxAddonPeriodRate) {
             revert InvalidCreditLineConfiguration();
         }
+        if (config.minRevokePeriods > config.maxRevokePeriods) {
+            revert InvalidCreditLineConfiguration();
+        }
 
         _config = config;
 
@@ -277,6 +280,7 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
         terms.interestRateSecondary = borrowerConfig.interestRateSecondary;
         terms.interestFormula = borrowerConfig.interestFormula;
         terms.autoRepayment = borrowerConfig.autoRepayment;
+        terms.revokePeriods = borrowerConfig.revokePeriods;
 
         if (terms.addonRecipient != address(0)) {
             terms.addonAmount = calculateAddonAmount(
@@ -404,6 +408,13 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
             revert InvalidBorrowerConfiguration();
         }
         if (config.addonPeriodRate > _config.maxAddonPeriodRate) {
+            revert InvalidBorrowerConfiguration();
+        }
+
+        if (config.revokePeriods < _config.minRevokePeriods) {
+            revert InvalidBorrowerConfiguration();
+        }
+        if (config.revokePeriods > _config.maxRevokePeriods) {
             revert InvalidBorrowerConfiguration();
         }
 

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -272,7 +272,6 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
 
         terms.token = _token;
         terms.treasury = _config.treasury;
-        terms.addonRecipient = _config.addonRecipient;
         terms.periodInSeconds = _config.periodInSeconds;
         terms.interestRateFactor = _config.interestRateFactor;
         terms.durationInPeriods = durationInPeriods.toUint32();
@@ -281,15 +280,12 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
         terms.interestFormula = borrowerConfig.interestFormula;
         terms.autoRepayment = borrowerConfig.autoRepayment;
         terms.revokePeriods = borrowerConfig.revokePeriods;
-
-        if (terms.addonRecipient != address(0)) {
-            terms.addonAmount = calculateAddonAmount(
-                borrowAmount,
-                durationInPeriods,
-                borrowerConfig.addonFixedRate,
-                borrowerConfig.addonPeriodRate
-            ).toUint64();
-        }
+        terms.addonAmount = calculateAddonAmount(
+            borrowAmount,
+            durationInPeriods,
+            borrowerConfig.addonFixedRate,
+            borrowerConfig.addonPeriodRate
+        ).toUint64();
     }
 
     /// @inheritdoc ICreditLineConfigurable

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -174,7 +174,7 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
         if (config.minAddonPeriodRate > config.maxAddonPeriodRate) {
             revert InvalidCreditLineConfiguration();
         }
-        if (config.minRevokePeriods > config.maxRevokePeriods) {
+        if (config.minRevocationPeriods > config.maxRevocationPeriods) {
             revert InvalidCreditLineConfiguration();
         }
 
@@ -279,7 +279,7 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
         terms.interestRateSecondary = borrowerConfig.interestRateSecondary;
         terms.interestFormula = borrowerConfig.interestFormula;
         terms.autoRepayment = borrowerConfig.autoRepayment;
-        terms.revokePeriods = borrowerConfig.revokePeriods;
+        terms.revocationPeriods = borrowerConfig.revocationPeriods;
         terms.addonAmount = calculateAddonAmount(
             borrowAmount,
             durationInPeriods,
@@ -407,10 +407,10 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
             revert InvalidBorrowerConfiguration();
         }
 
-        if (config.revokePeriods < _config.minRevokePeriods) {
+        if (config.revocationPeriods < _config.minRevocationPeriods) {
             revert InvalidBorrowerConfiguration();
         }
-        if (config.revokePeriods > _config.maxRevokePeriods) {
+        if (config.revocationPeriods > _config.maxRevocationPeriods) {
             revert InvalidBorrowerConfiguration();
         }
 

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -145,28 +145,28 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     }
 
     /// @inheritdoc ILiquidityPoolAccountable
-    function withdraw(address creditLine, uint256 borrowable, uint256 addons) external onlyOwner {
+    function withdraw(address creditLine, uint256 borrowableAmount, uint256 addonAmount) external onlyOwner {
         if (creditLine == address(0)) {
             revert Error.ZeroAddress();
         }
-        if (borrowable == 0 && addons == 0) {
+        if (borrowableAmount == 0 && addonAmount == 0) {
             revert Error.InvalidAmount();
         }
 
         CreditLineBalance storage balance = _creditLineBalances[creditLine];
-        if (balance.borrowable < borrowable) {
+        if (balance.borrowable < borrowableAmount) {
             revert InsufficientBalance();
         }
-        if (balance.addons < addons) {
+        if (balance.addons < addonAmount) {
             revert InsufficientBalance();
         }
 
-        balance.borrowable -= borrowable.toUint128();
-        balance.addons -= addons.toUint128();
+        balance.borrowable -= borrowableAmount.toUint128();
+        balance.addons -= addonAmount.toUint128();
 
-        IERC20(ICreditLine(creditLine).token()).safeTransfer(msg.sender, borrowable + addons);
+        IERC20(ICreditLine(creditLine).token()).safeTransfer(msg.sender, borrowableAmount + addonAmount);
 
-        emit Withdrawal(creditLine, borrowable, addons);
+        emit Withdrawal(creditLine, borrowableAmount, addonAmount);
     }
 
     /// @inheritdoc ILiquidityPoolAccountable

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -138,7 +138,7 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
             token.approve(_market, type(uint256).max);
         }
 
-        _creditLineBalances[creditLine].borrowable += amount.toUint128();
+        _creditLineBalances[creditLine].borrowable += amount.toUint64();
         token.safeTransferFrom(msg.sender, address(this), amount);
 
         emit Deposit(creditLine, amount);
@@ -161,8 +161,8 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
             revert InsufficientBalance();
         }
 
-        balance.borrowable -= borrowableAmount.toUint128();
-        balance.addons -= addonAmount.toUint128();
+        balance.borrowable -= borrowableAmount.toUint64();
+        balance.addons -= addonAmount.toUint64();
 
         IERC20(ICreditLine(creditLine).token()).safeTransfer(msg.sender, borrowableAmount + addonAmount);
 
@@ -234,7 +234,7 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     function onAfterLoanPayment(uint256 loanId, uint256 amount) external whenNotPaused onlyMarket returns (bool) {
         address creditLine = _creditLines[loanId];
         if (creditLine != address(0)) {
-            _creditLineBalances[creditLine].borrowable += amount.toUint128();
+            _creditLineBalances[creditLine].borrowable += amount.toUint64();
         }
 
         return true;

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -241,13 +241,13 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     }
 
     /// @inheritdoc ILiquidityPool
-    function onBeforeLoanRevoke(uint256 loanId) external view whenNotPaused onlyMarket returns (bool) {
+    function onBeforeLoanRevocation(uint256 loanId) external view whenNotPaused onlyMarket returns (bool) {
         loanId; // To prevent compiler warning about unused variable
         return true;
     }
 
     /// @inheritdoc ILiquidityPool
-    function onAfterLoanRevoke(uint256 loanId) external whenNotPaused onlyMarket returns (bool) {
+    function onAfterLoanRevocation(uint256 loanId) external whenNotPaused onlyMarket returns (bool) {
         address creditLine = _creditLines[loanId];
         if (creditLine != address(0)) {
             Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -240,6 +240,25 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
         return true;
     }
 
+    /// @inheritdoc ILiquidityPool
+    function onBeforeLoanRevoke(uint256 loanId) external view whenNotPaused onlyMarket returns (bool) {
+        loanId; // To prevent compiler warning about unused variable
+        return true;
+    }
+
+    /// @inheritdoc ILiquidityPool
+    function onAfterLoanRevoke(uint256 loanId) external whenNotPaused onlyMarket returns (bool) {
+        address creditLine = _creditLines[loanId];
+        if (creditLine != address(0)) {
+            Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
+            CreditLineBalance storage balance = _creditLineBalances[creditLine];
+            balance.borrowable += loan.initialBorrowAmount;
+            balance.addons -= loan.addonAmount;
+        }
+
+        return true;
+    }
+
     // -------------------------------------------- //
     //  View functions                              //
     // -------------------------------------------- //

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -9,6 +9,7 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/P
 
 import { Loan } from "../common/libraries/Loan.sol";
 import { Error } from "../common/libraries/Error.sol";
+import { SafeCast } from "../common/libraries/SafeCast.sol";
 
 import { ICreditLine } from "../common/interfaces/core/ICreditLine.sol";
 import { ILendingMarket } from "../common/interfaces/core/ILendingMarket.sol";
@@ -20,6 +21,7 @@ import { ILiquidityPoolAccountable } from "../common/interfaces/ILiquidityPoolAc
 /// @dev Implementation of the accountable liquidity pool contract.
 contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, ILiquidityPoolAccountable {
     using SafeERC20 for IERC20;
+    using SafeCast for uint256;
 
     // -------------------------------------------- //
     //  Storage variables                           //
@@ -35,14 +37,11 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     mapping(uint256 => address) internal _creditLines;
 
     /// @dev Mapping of a credit line to its token balance.
-    mapping(address => uint256) internal _creditLineBalances;
+    mapping(address => CreditLineBalance) internal _creditLineBalances;
 
     // -------------------------------------------- //
     //  Errors                                      //
     // -------------------------------------------- //
-
-    /// @dev Thrown when the token source balance is zero.
-    error ZeroBalance();
 
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
@@ -139,47 +138,49 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
             token.approve(_market, type(uint256).max);
         }
 
-        _creditLineBalances[creditLine] += amount;
+        _creditLineBalances[creditLine].borrowable += amount.toUint128();
         token.safeTransferFrom(msg.sender, address(this), amount);
+
         emit Deposit(creditLine, amount);
     }
 
     /// @inheritdoc ILiquidityPoolAccountable
-    function withdraw(address tokenSource, uint256 amount) external onlyOwner {
-        if (tokenSource == address(0)) {
+    function withdraw(address creditLine, uint256 borrowable, uint256 addons) external onlyOwner {
+        if (creditLine == address(0)) {
+            revert Error.ZeroAddress();
+        }
+        if (borrowable == 0 && addons == 0) {
+            revert Error.InvalidAmount();
+        }
+
+        CreditLineBalance storage balance = _creditLineBalances[creditLine];
+        if (balance.borrowable < borrowable) {
+            revert InsufficientBalance();
+        }
+        if (balance.addons < addons) {
+            revert InsufficientBalance();
+        }
+
+        balance.borrowable -= borrowable.toUint128();
+        balance.addons -= addons.toUint128();
+
+        IERC20(ICreditLine(creditLine).token()).safeTransfer(msg.sender, borrowable + addons);
+
+        emit Withdrawal(creditLine, borrowable, addons);
+    }
+
+    /// @inheritdoc ILiquidityPoolAccountable
+    function rescue(address token, uint256 amount) external onlyOwner {
+        if (token == address(0)) {
             revert Error.ZeroAddress();
         }
         if (amount == 0) {
             revert Error.InvalidAmount();
         }
 
-        // Withdraw credit line balance
-        uint256 balance = _creditLineBalances[tokenSource];
-        if (balance != 0) {
-            if (balance < amount) {
-                revert InsufficientBalance();
-            }
-            _creditLineBalances[tokenSource] -= amount;
-            IERC20(ICreditLine(tokenSource).token()).safeTransfer(msg.sender, amount);
-            emit Withdrawal(tokenSource, amount);
-            return;
-        }
+        IERC20(token).safeTransfer(msg.sender, amount);
 
-        // Withdraw token balance
-        bytes memory data = abi.encodeWithSelector(IERC20.balanceOf.selector, address(this));
-        (bool success, bytes memory returnData) = tokenSource.staticcall(data);
-        if (success && returnData.length == 32) {
-            balance = abi.decode(returnData, (uint256));
-            if (balance < amount) {
-                revert InsufficientBalance();
-            }
-            IERC20(tokenSource).safeTransfer(msg.sender, amount);
-            emit Withdrawal(tokenSource, amount);
-            return;
-        }
-
-        // Revert with zero balance error
-        revert ZeroBalance();
+        emit Rescue(token, amount);
     }
 
     /// @inheritdoc ILiquidityPoolAccountable
@@ -212,7 +213,11 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
 
     /// @inheritdoc ILiquidityPool
     function onAfterLoanTaken(uint256 loanId, address creditLine) external whenNotPaused onlyMarket returns (bool) {
-        _creditLineBalances[creditLine] -= ILendingMarket(_market).getLoanState(loanId).initialBorrowAmount;
+        Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
+        CreditLineBalance storage balance = _creditLineBalances[creditLine];
+        balance.borrowable -= loan.initialBorrowAmount;
+        balance.addons += loan.addonAmount;
+
         _creditLines[loanId] = creditLine;
 
         return true;
@@ -229,7 +234,7 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     function onAfterLoanPayment(uint256 loanId, uint256 amount) external whenNotPaused onlyMarket returns (bool) {
         address creditLine = _creditLines[loanId];
         if (creditLine != address(0)) {
-            _creditLineBalances[creditLine] += amount;
+            _creditLineBalances[creditLine].borrowable += amount.toUint128();
         }
 
         return true;
@@ -240,21 +245,8 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     // -------------------------------------------- //
 
     /// @inheritdoc ILiquidityPoolAccountable
-    function getTokenBalance(address tokenSource) external view returns (uint256) {
-        // Return credit line balance
-        uint256 balance = _creditLineBalances[tokenSource];
-        if (balance != 0) {
-            return balance;
-        }
-
-        // Return token balance
-        bytes memory data = abi.encodeWithSelector(IERC20.balanceOf.selector, address(this));
-        (bool success, bytes memory returnData) = tokenSource.staticcall(data);
-        if (success && returnData.length == 32) {
-            return abi.decode(returnData, (uint256));
-        }
-
-        return 0;
+    function getCreditLineBalance(address creditLine) external view returns (CreditLineBalance memory) {
+        return _creditLineBalances[creditLine];
     }
 
     /// @inheritdoc ILiquidityPoolAccountable

--- a/src/mocks/LendingMarketMock.sol
+++ b/src/mocks/LendingMarketMock.sol
@@ -45,6 +45,11 @@ contract LendingMarketMock is ILendingMarket {
         emit RepayLoanCalled(loanId, repayAmount);
     }
 
+    function revokeLoan(uint256 loanId) external pure {
+        loanId; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function freeze(uint256 loanId) external pure {
         loanId; // To prevent compiler warning about unused variable
         revert Error.NotImplemented();

--- a/src/mocks/LiquidityPoolMock.sol
+++ b/src/mocks/LiquidityPoolMock.sol
@@ -19,6 +19,9 @@ contract LiquidityPoolMock is ILiquidityPool {
     event OnBeforeLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
 
+    event OnBeforeLoanRevokeCalled(uint256 indexed loanId);
+    event OnAfterLoanRevokeCalled(uint256 indexed loanId);
+
     // -------------------------------------------- //
     //  Storage variables                           //
     // -------------------------------------------- //
@@ -28,6 +31,9 @@ contract LiquidityPoolMock is ILiquidityPool {
 
     bool private _onBeforeLoanPaymentResult;
     bool private _onAfterLoanPaymentResult;
+
+    bool private _onBeforeLoanRevokeResult;
+    bool private _onAfterLoanRevokeResult;
 
     // -------------------------------------------- //
     //  ILiquidityPoolFactory functions             //
@@ -51,6 +57,16 @@ contract LiquidityPoolMock is ILiquidityPool {
     function onAfterLoanPayment(uint256 loanId, uint256 repayAmount) external returns (bool) {
         emit OnAfterLoanPaymentCalled(loanId, repayAmount);
         return _onAfterLoanPaymentResult;
+    }
+
+    function onBeforeLoanRevoke(uint256 loanId) external returns (bool) {
+        emit OnBeforeLoanRevokeCalled(loanId);
+        return _onBeforeLoanRevokeResult;
+    }
+
+    function onAfterLoanRevoke(uint256 loanId) external returns (bool) {
+        emit OnAfterLoanRevokeCalled(loanId);
+        return _onAfterLoanRevokeResult;
     }
 
     function market() external pure returns (address) {
@@ -83,5 +99,13 @@ contract LiquidityPoolMock is ILiquidityPool {
 
     function mockOnAfterLoanPaymentResult(bool result) external {
         _onAfterLoanPaymentResult = result;
+    }
+
+    function mockOnBeforeLoanRevokeResult(bool result) external {
+        _onBeforeLoanRevokeResult = result;
+    }
+
+    function mockOnAfterLoanRevokeResult(bool result) external {
+        _onAfterLoanRevokeResult = result;
     }
 }

--- a/src/mocks/LiquidityPoolMock.sol
+++ b/src/mocks/LiquidityPoolMock.sol
@@ -19,8 +19,8 @@ contract LiquidityPoolMock is ILiquidityPool {
     event OnBeforeLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
 
-    event OnBeforeLoanRevokeCalled(uint256 indexed loanId);
-    event OnAfterLoanRevokeCalled(uint256 indexed loanId);
+    event OnBeforeLoanRevocationCalled(uint256 indexed loanId);
+    event OnAfterLoanRevocationCalled(uint256 indexed loanId);
 
     // -------------------------------------------- //
     //  Storage variables                           //
@@ -32,8 +32,8 @@ contract LiquidityPoolMock is ILiquidityPool {
     bool private _onBeforeLoanPaymentResult;
     bool private _onAfterLoanPaymentResult;
 
-    bool private _onBeforeLoanRevokeResult;
-    bool private _onAfterLoanRevokeResult;
+    bool private _onBeforeLoanRevocationResult;
+    bool private _onAfterLoanRevocationResult;
 
     // -------------------------------------------- //
     //  ILiquidityPoolFactory functions             //
@@ -59,14 +59,14 @@ contract LiquidityPoolMock is ILiquidityPool {
         return _onAfterLoanPaymentResult;
     }
 
-    function onBeforeLoanRevoke(uint256 loanId) external returns (bool) {
-        emit OnBeforeLoanRevokeCalled(loanId);
-        return _onBeforeLoanRevokeResult;
+    function onBeforeLoanRevocation(uint256 loanId) external returns (bool) {
+        emit OnBeforeLoanRevocationCalled(loanId);
+        return _onBeforeLoanRevocationResult;
     }
 
-    function onAfterLoanRevoke(uint256 loanId) external returns (bool) {
-        emit OnAfterLoanRevokeCalled(loanId);
-        return _onAfterLoanRevokeResult;
+    function onAfterLoanRevocation(uint256 loanId) external returns (bool) {
+        emit OnAfterLoanRevocationCalled(loanId);
+        return _onAfterLoanRevocationResult;
     }
 
     function market() external pure returns (address) {
@@ -101,11 +101,11 @@ contract LiquidityPoolMock is ILiquidityPool {
         _onAfterLoanPaymentResult = result;
     }
 
-    function mockOnBeforeLoanRevokeResult(bool result) external {
-        _onBeforeLoanRevokeResult = result;
+    function mockOnBeforeLoanRevocationResult(bool result) external {
+        _onBeforeLoanRevocationResult = result;
     }
 
-    function mockOnAfterLoanRevokeResult(bool result) external {
-        _onAfterLoanRevokeResult = result;
+    function mockOnAfterLoanRevocationResult(bool result) external {
+        _onAfterLoanRevocationResult = result;
     }
 }

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -1311,6 +1311,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration(address caller) private {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1335,6 +1336,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration_Revert_IfContractIsPaused() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1350,6 +1352,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration_Revert_IfCallerNotLender() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1362,13 +1365,13 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration_Revert_IfLoanNotExist() public {
         vm.prank(LENDER_1);
-        uint256 newDurationInPeriods = 2;
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
-        market.updateLoanDuration(LOAN_ID_NONEXISTENT, newDurationInPeriods);
+        market.updateLoanDuration(LOAN_ID_NONEXISTENT, 100);
     }
 
     function test_updateLoanDuration_Revert_IfRepaidLoan() public {
         configureMarket();
+
         uint256 loanId = createRepaidLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1381,6 +1384,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration_Revert_IfSameLoanDuration() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1393,6 +1397,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanDuration_Revert_IfDecreasedLoanDuration() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1409,6 +1414,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRatePrimary(address caller) private {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1434,6 +1440,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRatePrimary_Revert_IfContractIsPaused() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1449,6 +1456,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRatePrimary_Revert_IfCallerNotLender() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1462,11 +1470,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRatePrimary_Revert_IfLoanNotExist() public {
         vm.prank(LENDER_1);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
-        market.updateLoanInterestRatePrimary(LOAN_ID_NONEXISTENT, 1);
+        market.updateLoanInterestRatePrimary(LOAN_ID_NONEXISTENT, 100);
     }
 
     function test_updateLoanInterestRatePrimary_Revert_IfLoadIsRepaid() public {
         configureMarket();
+
         uint256 loanId = createRepaidLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1495,6 +1504,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRateSecondary(address caller) private {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1520,6 +1530,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRateSecondary_Revert_IfContractIsPaused() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1535,6 +1546,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRateSecondary_Revert_IfCallerNotLender() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1548,11 +1560,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRateSecondary_Revert_IfLoanNotExist() public {
         vm.prank(LENDER_1);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
-        market.updateLoanInterestRateSecondary(LOAN_ID_NONEXISTENT, 1);
+        market.updateLoanInterestRateSecondary(LOAN_ID_NONEXISTENT, 100);
     }
 
     function test_updateLoanInterestRateSecondary_Revert_IfLoadIsRepaid() public {
         configureMarket();
+
         uint256 loanId = createRepaidLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 
@@ -1565,6 +1578,7 @@ contract LendingMarketTest is Test {
 
     function test_updateLoanInterestRateSecondary_Revert_IfIncreasedInterestRate() public {
         configureMarket();
+
         uint256 loanId = createActiveLoan(1);
         Loan.State memory loan = market.getLoanState(loanId);
 

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -442,9 +442,10 @@ contract LendingMarketTest is Test {
     function test_registerCreditLine_IfOwner() public {
         assertEq(market.getCreditLineLender(address(creditLine)), address(0));
 
-        vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(market));
         emit CreditLineRegistered(LENDER, address(creditLine));
+
+        vm.prank(OWNER);
         market.registerCreditLine(LENDER, address(creditLine));
 
         assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
@@ -453,9 +454,10 @@ contract LendingMarketTest is Test {
     function test_registerCreditLine_IfRegistry() public {
         assertEq(market.getCreditLineLender(address(creditLine)), address(0));
 
-        vm.prank(REGISTRY_1);
         vm.expectEmit(true, true, true, true, address(market));
         emit CreditLineRegistered(LENDER, address(creditLine));
+
+        vm.prank(REGISTRY_1);
         market.registerCreditLine(LENDER, address(creditLine));
 
         assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
@@ -508,9 +510,10 @@ contract LendingMarketTest is Test {
     function test_registerLiquidityPool_IfOwner() public {
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), address(0));
 
-        vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(market));
         emit LiquidityPoolRegistered(LENDER, address(liquidityPool));
+
+        vm.prank(OWNER);
         market.registerLiquidityPool(LENDER, address(liquidityPool));
 
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
@@ -519,9 +522,10 @@ contract LendingMarketTest is Test {
     function test_registerLiquidityPool_IfRegistry() public {
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), address(0));
 
-        vm.prank(REGISTRY_1);
         vm.expectEmit(true, true, true, true, address(market));
         emit LiquidityPoolRegistered(LENDER, address(liquidityPool));
+
+        vm.prank(REGISTRY_1);
         market.registerLiquidityPool(LENDER, address(liquidityPool));
 
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
@@ -667,9 +671,10 @@ contract LendingMarketTest is Test {
 
         assertEq(market.getLiquidityPoolByCreditLine(address(creditLine)), address(0));
 
-        vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(market));
         emit LiquidityPoolAssignedToCreditLine(address(creditLine), address(liquidityPool), address(0));
+
+        vm.prank(LENDER);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
 
         assertEq(market.getLiquidityPoolByCreditLine(address(creditLine)), address(liquidityPool));
@@ -1284,7 +1289,7 @@ contract LendingMarketTest is Test {
     //  Test `updateLoanDuration` function          //
     // -------------------------------------------- //
 
-    function test_updateLoanDuration(address caller) private {
+    function test_updateLoanDuration(address lender) private {
         configureMarket();
 
         uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
@@ -1292,9 +1297,10 @@ contract LendingMarketTest is Test {
 
         uint256 newDurationInPeriods = loan.durationInPeriods + 2;
 
-        vm.prank(caller);
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanDurationUpdated(loanId, newDurationInPeriods, loan.durationInPeriods);
+
+        vm.prank(lender);
         market.updateLoanDuration(loanId, newDurationInPeriods);
 
         loan = market.getLoanState(loanId);
@@ -1394,7 +1400,7 @@ contract LendingMarketTest is Test {
     //  Test `updateLoanInterestRatePrimary` function
     // -------------------------------------------- //
 
-    function test_updateLoanInterestRatePrimary(address caller) private {
+    function test_updateLoanInterestRatePrimary(address lender) private {
         configureMarket();
 
         uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
@@ -1403,9 +1409,10 @@ contract LendingMarketTest is Test {
         uint256 oldInterestRatePrimary = loan.interestRatePrimary;
         uint256 newInterestRatePrimary = oldInterestRatePrimary - 1;
 
-        vm.prank(caller);
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanInterestRatePrimaryUpdated(loanId, newInterestRatePrimary, oldInterestRatePrimary);
+
+        vm.prank(lender);
         market.updateLoanInterestRatePrimary(loanId, newInterestRatePrimary);
 
         loan = market.getLoanState(loanId);
@@ -1491,7 +1498,7 @@ contract LendingMarketTest is Test {
     //  Test `updateLoanInterestRateSecondary` function
     // -------------------------------------------- //
 
-    function test_updateLoanInterestRateSecondary(address caller) private {
+    function test_updateLoanInterestRateSecondary(address lender) private {
         configureMarket();
 
         uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
@@ -1500,9 +1507,10 @@ contract LendingMarketTest is Test {
         uint256 oldInterestRateSecondary = loan.interestRateSecondary;
         uint256 newInterestRateSecondary = oldInterestRateSecondary - 1;
 
-        vm.prank(caller);
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanInterestRateSecondaryUpdated(loanId, newInterestRateSecondary, oldInterestRateSecondary);
+
+        vm.prank(lender);
         market.updateLoanInterestRateSecondary(loanId, newInterestRateSecondary);
 
         loan = market.getLoanState(loanId);

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -36,8 +36,8 @@ contract LendingMarketTest is Test {
     event OnBeforeLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
 
-    event OnBeforeLoanRevokedCalled(uint256 indexed loanId);
-    event OnAfterLoanRevokedCalled(uint256 indexed loanId);
+    event OnBeforeLoanRevocationdCalled(uint256 indexed loanId);
+    event OnAfterLoanRevocationdCalled(uint256 indexed loanId);
 
     event MarketRegistryChanged(address indexed newRegistry, address indexed oldRegistry);
     event LiquidityPoolRegistered(address indexed lender, address indexed liquidityPool);
@@ -144,8 +144,8 @@ contract LendingMarketTest is Test {
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE = 50;
     uint32 private constant CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE = 10;
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE = 50;
-    uint16 private constant CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS = 2;
-    uint16 private constant CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS = 4;
+    uint16 private constant CREDIT_LINE_CONFIG_MIN_REVOCATION_PERIODS = 2;
+    uint16 private constant CREDIT_LINE_CONFIG_MAX_REVOCATION_PERIODS = 4;
 
     uint32 private constant BORROWER_CONFIG_ADDON_FIXED_RATE = 15;
     uint32 private constant BORROWER_CONFIG_ADDON_PERIOD_RATE = 20;
@@ -156,7 +156,7 @@ contract LendingMarketTest is Test {
     uint64 private constant BORROWER_CONFIG_MAX_BORROW_AMOUNT = 800;
     uint32 private constant BORROWER_CONFIG_INTEREST_RATE_PRIMARY = 5;
     uint32 private constant BORROWER_CONFIG_INTEREST_RATE_SECONDARY = 6;
-    uint16 private constant BORROWER_CONFIG_REVOKE_PERIODS = 3;
+    uint16 private constant BORROWER_CONFIG_REVOCATION_PERIODS = 3;
     bool private constant BORROWER_CONFIG_AUTOREPAYMENT = true;
     Interest.Formula private constant BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND = Interest.Formula.Compound;
     ICreditLineConfigurable.BorrowPolicy private constant BORROWER_CONFIG_BORROW_POLICY_DECREASE =
@@ -279,7 +279,7 @@ contract LendingMarketTest is Test {
             interestFormula: BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND,
             borrowPolicy: BORROWER_CONFIG_BORROW_POLICY_DECREASE,
             autoRepayment: BORROWER_CONFIG_AUTOREPAYMENT,
-            revokePeriods: BORROWER_CONFIG_REVOKE_PERIODS
+            revocationPeriods: BORROWER_CONFIG_REVOCATION_PERIODS
         });
     }
 
@@ -318,8 +318,8 @@ contract LendingMarketTest is Test {
             maxAddonFixedRate: CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE,
             minAddonPeriodRate: CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE,
             maxAddonPeriodRate: CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE,
-            minRevokePeriods: CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS,
-            maxRevokePeriods: CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS
+            minRevocationPeriods: CREDIT_LINE_CONFIG_MIN_REVOCATION_PERIODS,
+            maxRevocationPeriods: CREDIT_LINE_CONFIG_MAX_REVOCATION_PERIODS
         });
     }
 
@@ -337,7 +337,7 @@ contract LendingMarketTest is Test {
             interestFormula: borrowerConfig.interestFormula,
             autoRepayment: borrowerConfig.autoRepayment,
             addonAmount: ADDON_AMOUNT,
-            revokePeriods: borrowerConfig.revokePeriods
+            revocationPeriods: borrowerConfig.revocationPeriods
         });
     }
 
@@ -777,9 +777,9 @@ contract LendingMarketTest is Test {
         assertEq(loan.trackedBorrowBalance, totalBorrowAmount);
         assertEq(loan.addonAmount, terms.addonAmount);
         assertEq(loan.autoRepayment, terms.autoRepayment);
-        assertEq(loan.revokePeriods, terms.revokePeriods);
         assertEq(loan.periodInSeconds, terms.periodInSeconds);
         assertEq(loan.durationInPeriods, terms.durationInPeriods);
+        assertEq(loan.revocationPeriods, terms.revocationPeriods);
         assertEq(loan.interestRateFactor, terms.interestRateFactor);
         assertEq(loan.interestRatePrimary, terms.interestRatePrimary);
         assertEq(loan.interestRateSecondary, terms.interestRateSecondary);

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -777,6 +777,7 @@ contract LendingMarketTest is Test {
 
         assertEq(loan.token, terms.token);
         assertEq(loan.treasury, terms.treasury);
+        assertEq(loan.addonAmount, terms.addonAmount);
         assertEq(loan.autoRepayment, terms.autoRepayment);
         assertEq(loan.revokePeriods, terms.revokePeriods);
         assertEq(loan.periodInSeconds, terms.periodInSeconds);

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -141,6 +141,8 @@ contract LendingMarketTest is Test {
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE = 50;
     uint32 private constant CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE = 10;
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE = 50;
+    uint16 private constant CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS = 2;
+    uint16 private constant CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS = 4;
 
     uint32 private constant BORROWER_CONFIG_ADDON_FIXED_RATE = 15;
     uint32 private constant BORROWER_CONFIG_ADDON_PERIOD_RATE = 20;
@@ -151,6 +153,7 @@ contract LendingMarketTest is Test {
     uint64 private constant BORROWER_CONFIG_MAX_BORROW_AMOUNT = 800;
     uint32 private constant BORROWER_CONFIG_INTEREST_RATE_PRIMARY = 5;
     uint32 private constant BORROWER_CONFIG_INTEREST_RATE_SECONDARY = 6;
+    uint16 private constant BORROWER_CONFIG_REVOKE_PERIODS = 3;
     bool private constant BORROWER_CONFIG_AUTOREPAYMENT = true;
     Interest.Formula private constant BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND = Interest.Formula.Compound;
     ICreditLineConfigurable.BorrowPolicy private constant BORROWER_CONFIG_BORROW_POLICY_DECREASE =
@@ -272,7 +275,8 @@ contract LendingMarketTest is Test {
             addonPeriodRate: BORROWER_CONFIG_ADDON_PERIOD_RATE,
             interestFormula: BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND,
             borrowPolicy: BORROWER_CONFIG_BORROW_POLICY_DECREASE,
-            autoRepayment: BORROWER_CONFIG_AUTOREPAYMENT
+            autoRepayment: BORROWER_CONFIG_AUTOREPAYMENT,
+            revokePeriods: BORROWER_CONFIG_REVOKE_PERIODS
         });
     }
 
@@ -311,7 +315,9 @@ contract LendingMarketTest is Test {
             minAddonFixedRate: CREDIT_LINE_CONFIG_MIN_ADDON_FIXED_RATE,
             maxAddonFixedRate: CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE,
             minAddonPeriodRate: CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE,
-            maxAddonPeriodRate: CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE
+            maxAddonPeriodRate: CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE,
+            minRevokePeriods: CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS,
+            maxRevokePeriods: CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS
         });
     }
 
@@ -329,7 +335,8 @@ contract LendingMarketTest is Test {
             interestFormula: borrowerConfig.interestFormula,
             addonRecipient: creditLineConfig.addonRecipient,
             autoRepayment: borrowerConfig.autoRepayment,
-            addonAmount: ADDON_AMOUNT
+            addonAmount: ADDON_AMOUNT,
+            revokePeriods: borrowerConfig.revokePeriods
         });
     }
 
@@ -769,7 +776,9 @@ contract LendingMarketTest is Test {
         assertEq(loan.trackedBorrowBalance, borrowAmount + terms.addonAmount);
 
         assertEq(loan.token, terms.token);
+        assertEq(loan.treasury, terms.treasury);
         assertEq(loan.autoRepayment, terms.autoRepayment);
+        assertEq(loan.revokePeriods, terms.revokePeriods);
         assertEq(loan.periodInSeconds, terms.periodInSeconds);
         assertEq(loan.durationInPeriods, terms.durationInPeriods);
         assertEq(loan.interestRateFactor, terms.interestRateFactor);

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -830,7 +830,7 @@ contract LendingMarketTest is Test {
     //  Test `repayLoan` function                   //
     // -------------------------------------------- //
 
-    function repayLoan(uint256 loanId, bool autoRepaymnet) private {
+    function repayLoan(uint256 loanId, bool autoRepaymnet, uint256 skipPeriodsBeforePartialRepayment, uint256 skipPeriodsFullRepayment) private {
         Loan.State memory loan = market.getLoanState(loanId);
 
         // Repayment mode
@@ -843,7 +843,7 @@ contract LendingMarketTest is Test {
 
         // Partial repayment
 
-        skip(loan.periodInSeconds * 2);
+        skip(loan.periodInSeconds * skipPeriodsBeforePartialRepayment);
 
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         uint256 repayAmount = outstandingBalance / 2;
@@ -865,7 +865,7 @@ contract LendingMarketTest is Test {
 
         // Full repayment
 
-        skip(loan.periodInSeconds * 3);
+        skip(loan.periodInSeconds * skipPeriodsFullRepayment);
 
         outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER));
@@ -886,32 +886,74 @@ contract LendingMarketTest is Test {
 
     function test_repayLoan_IfLoanIsActive() public {
         configureMarket();
-        repayLoan(createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1), false);
+        bool autoRepayment = false;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createActiveLoan(BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IfLoanIsFrozen() public {
         configureMarket();
-        repayLoan(createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 1), false);
+        bool autoRepayment = false;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IfLoanIsDefaulted() public {
         configureMarket();
-        repayLoan(createDefaultedLoan(BORROWER, BORROW_AMOUNT, false, 1), false);
+        bool autoRepayment = false;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createDefaultedLoan(BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IfLoanIsActive_AutoRepayment() public {
         configureMarket();
-        repayLoan(createActiveLoan(BORROWER, BORROW_AMOUNT, true, 1), true);
+        bool autoRepayment = true;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createActiveLoan(BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IfLoanIsFrozen_AutoRepayment() public {
         configureMarket();
-        repayLoan(createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, true, 1), true);
+        bool autoRepayment = true;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IfLoanIsDefaulted_AutoRepayment() public {
         configureMarket();
-        repayLoan(createDefaultedLoan(BORROWER, BORROW_AMOUNT, true, 1), true);
+        bool autoRepayment = true;
+        uint256 skipPeriodsBeforePartialRepayment = 2;
+        uint256 skipPeriodsFullRepayment = 3;
+        repayLoan(
+            createDefaultedLoan(BORROWER, BORROW_AMOUNT, autoRepayment, 1),
+            autoRepayment,
+            skipPeriodsBeforePartialRepayment,
+            skipPeriodsFullRepayment);
     }
 
     function test_repayLoan_IRepaymentAmountIsUint256Max() public {

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -193,6 +193,9 @@ contract LendingMarketTest is Test {
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
         vm.stopPrank();
 
+        vm.prank(BORROWER_1);
+        token.approve(address(market), type(uint256).max);
+
         vm.prank(address(liquidityPool));
         token.approve(address(market), type(uint256).max);
     }
@@ -240,10 +243,8 @@ contract LendingMarketTest is Test {
         assertEq(outstandingBalance != 0, true);
         token.mint(BORROWER_1, outstandingBalance);
 
-        vm.startPrank(BORROWER_1);
-        token.approve(address(market), outstandingBalance);
+        vm.prank(BORROWER_1);
         market.repayLoan(loanId, outstandingBalance);
-        vm.stopPrank();
 
         outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         assertEq(outstandingBalance == 0, true);
@@ -846,9 +847,6 @@ contract LendingMarketTest is Test {
         assertEq(market.ownerOf(loanId), LENDER_1);
         assertEq(loan.trackedBorrowBalance >= 2, true);
 
-        vm.prank(BORROWER_1);
-        token.approve(address(market), type(uint256).max);
-
         // Repayment mode
         if (autoRepaymnet) {
             vm.startPrank(address(liquidityPool));
@@ -930,8 +928,6 @@ contract LendingMarketTest is Test {
         uint256 loanId = createActiveLoan(1);
 
         vm.startPrank(BORROWER_1);
-
-        token.approve(address(market), type(uint256).max);
 
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         assertEq(outstandingBalance != 0, true);
@@ -1029,9 +1025,6 @@ contract LendingMarketTest is Test {
 
         skip(loan.periodInSeconds * (loan.revocationPeriods - 1));
 
-        vm.prank(loan.borrower);
-        token.approve(address(market), borrowAmount);
-
         vm.expectEmit(true, true, true, true, address(liquidityPool));
         emit OnBeforeLoanRevocationCalled(loanId);
         vm.expectEmit(true, true, true, true, address(liquidityPool));
@@ -1079,8 +1072,7 @@ contract LendingMarketTest is Test {
 
         skip(1);
 
-        vm.startPrank(loan.borrower);
-        token.approve(address(market), 1);
+        vm.prank(loan.borrower);
         market.repayLoan(loanId, 1);
 
         vm.expectRevert(LendingMarket.RevocationIsProhibited.selector);

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -110,17 +110,18 @@ contract LendingMarketTest is Test {
     LiquidityPoolMock private liquidityPool;
 
     address private constant OWNER = address(bytes20(keccak256("owner")));
+    address private constant LENDER = address(bytes20(keccak256("lender")));
+    address private constant BORROWER = address(bytes20(keccak256("borrower")));
     address private constant ATTACKER = address(bytes20(keccak256("attacker")));
-    address private constant LENDER_1 = address(bytes20(keccak256("lender_1")));
+
     address private constant LENDER_2 = address(bytes20(keccak256("lender_2")));
-    address private constant BORROWER_1 = address(bytes20(keccak256("borrower_1")));
     address private constant BORROWER_2 = address(bytes20(keccak256("borrower_2")));
     address private constant BORROWER_3 = address(bytes20(keccak256("borrower_3")));
     address private constant REGISTRY_1 = address(bytes20(keccak256("registry_1")));
     address private constant REGISTRY_2 = address(bytes20(keccak256("registry_2")));
     address private constant CREDIT_LINE = address(bytes20(keccak256("credit_line")));
+    address private constant LENDER_ALIAS = address(bytes20(keccak256("lender_alias")));
     address private constant LOAN_TREASURY = address(bytes20(keccak256("loan_treasury")));
-    address private constant LENDER_1_ALIAS = address(bytes20(keccak256("lender_1_alias")));
 
     uint64 private constant ADDON_AMOUNT = 100;
     uint64 private constant BORROW_AMOUNT = 100;
@@ -181,14 +182,14 @@ contract LendingMarketTest is Test {
 
     function configureMarket() private {
         vm.startPrank(OWNER);
-        market.registerCreditLine(LENDER_1, address(creditLine));
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerCreditLine(LENDER, address(creditLine));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
         vm.stopPrank();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         token.approve(address(market), type(uint256).max);
 
         vm.prank(address(liquidityPool));
@@ -223,7 +224,7 @@ contract LendingMarketTest is Test {
         returns (address[] memory, ICreditLineConfigurable.BorrowerConfig[] memory)
     {
         address[] memory borrowers = new address[](3);
-        borrowers[0] = BORROWER_1;
+        borrowers[0] = BORROWER;
         borrowers[1] = BORROWER_2;
         borrowers[2] = BORROWER_3;
 
@@ -443,10 +444,10 @@ contract LendingMarketTest is Test {
 
         vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(market));
-        emit CreditLineRegistered(LENDER_1, address(creditLine));
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        emit CreditLineRegistered(LENDER, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
 
-        assertEq(market.getCreditLineLender(address(creditLine)), LENDER_1);
+        assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
     }
 
     function test_registerCreditLine_IfRegistry() public {
@@ -454,17 +455,17 @@ contract LendingMarketTest is Test {
 
         vm.prank(REGISTRY_1);
         vm.expectEmit(true, true, true, true, address(market));
-        emit CreditLineRegistered(LENDER_1, address(creditLine));
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        emit CreditLineRegistered(LENDER, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
 
-        assertEq(market.getCreditLineLender(address(creditLine)), LENDER_1);
+        assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
     }
 
     function test_registerCreditLine_Revert_IfOwner_ContractIsPaused() public {
         vm.startPrank(OWNER);
         market.pause();
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
     }
 
     function test_registerCreditLine_Revert_IfRegistry_ContractIsPaused() public {
@@ -472,13 +473,13 @@ contract LendingMarketTest is Test {
         market.pause();
         vm.prank(REGISTRY_1);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
     }
 
     function test_registerCreditLine_Revert_IfCallerNotRegistryOrOwner() public {
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
     }
 
     function test_registerCreditLine_Revert_IfLenderIsZeroAddress() public {
@@ -490,14 +491,14 @@ contract LendingMarketTest is Test {
     function test_registerCreditLine_Revert_IfCreditLineIsZeroAddress() public {
         vm.prank(OWNER);
         vm.expectRevert(Error.ZeroAddress.selector);
-        market.registerCreditLine(LENDER_1, address(0));
+        market.registerCreditLine(LENDER, address(0));
     }
 
     function test_registerCreditLine_Revert_IfCreditLineIsAlreadyRegistered() public {
         vm.startPrank(OWNER);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
         vm.expectRevert(LendingMarket.CreditLineAlreadyRegistered.selector);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
     }
 
     // -------------------------------------------- //
@@ -509,10 +510,10 @@ contract LendingMarketTest is Test {
 
         vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(market));
-        emit LiquidityPoolRegistered(LENDER_1, address(liquidityPool));
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        emit LiquidityPoolRegistered(LENDER, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
 
-        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER_1);
+        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
     }
 
     function test_registerLiquidityPool_IfRegistry() public {
@@ -520,17 +521,17 @@ contract LendingMarketTest is Test {
 
         vm.prank(REGISTRY_1);
         vm.expectEmit(true, true, true, true, address(market));
-        emit LiquidityPoolRegistered(LENDER_1, address(liquidityPool));
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        emit LiquidityPoolRegistered(LENDER, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
 
-        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER_1);
+        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
     }
 
     function test_registerLiquidityPool_Revert_IfOwner_ContractIsPaused() public {
         vm.startPrank(OWNER);
         market.pause();
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
     }
 
     function test_registerLiquidityPool_Revert_IfRegistry_ContractIsPaused() public {
@@ -538,13 +539,13 @@ contract LendingMarketTest is Test {
         market.pause();
         vm.prank(REGISTRY_1);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
     }
 
     function test_registerLiquidityPool_Revert_IfCallerNotRegistryOrOwner() public {
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
     }
 
     function test_registerLiquidityPool_Revert_IfLenderIsZeroAddress() public {
@@ -556,14 +557,14 @@ contract LendingMarketTest is Test {
     function test_registerLiquidityPool_Revert_IfLiquidityPoolIsZeroAddress() public {
         vm.prank(OWNER);
         vm.expectRevert(Error.ZeroAddress.selector);
-        market.registerLiquidityPool(LENDER_1, address(0));
+        market.registerLiquidityPool(LENDER, address(0));
     }
 
     function test_registerLiquidityPool_Revert_IfLiquidityPoolIsAlreadyRegistered() public {
         vm.startPrank(OWNER);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
         vm.expectRevert(LendingMarket.LiquidityPoolAlreadyRegistered.selector);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
     }
 
     // -------------------------------------------- //
@@ -573,11 +574,11 @@ contract LendingMarketTest is Test {
     function test_updateCreditLineLender() public {
         vm.startPrank(OWNER);
 
-        market.registerCreditLine(LENDER_1, address(creditLine));
-        assertEq(market.getCreditLineLender(address(creditLine)), LENDER_1);
+        market.registerCreditLine(LENDER, address(creditLine));
+        assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit CreditLineLenderUpdated(address(creditLine), LENDER_2, LENDER_1);
+        emit CreditLineLenderUpdated(address(creditLine), LENDER_2, LENDER);
         market.updateCreditLineLender(address(creditLine), LENDER_2);
 
         assertEq(market.getCreditLineLender(address(creditLine)), LENDER_2);
@@ -586,13 +587,13 @@ contract LendingMarketTest is Test {
     function test_updateCreditLineLender_Revert_IfCallerNotOwner() public {
         vm.prank(ATTACKER);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
-        market.updateCreditLineLender(address(creditLine), LENDER_1);
+        market.updateCreditLineLender(address(creditLine), LENDER);
     }
 
     function test_updateCreditLineLender_Revert_IfCreditLineIsZeroAddress() public {
         vm.prank(OWNER);
         vm.expectRevert(Error.ZeroAddress.selector);
-        market.updateCreditLineLender(address(0), LENDER_1);
+        market.updateCreditLineLender(address(0), LENDER);
     }
 
     function test_updateCreditLineLender_Revert_IfLenderIsZeroAddress() public {
@@ -603,9 +604,9 @@ contract LendingMarketTest is Test {
 
     function test_updateCreditLineLender_Revert_IfLenderAlreadyConfigured() public {
         vm.startPrank(OWNER);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        market.registerCreditLine(LENDER, address(creditLine));
         vm.expectRevert(Error.AlreadyConfigured.selector);
-        market.updateCreditLineLender(address(creditLine), LENDER_1);
+        market.updateCreditLineLender(address(creditLine), LENDER);
     }
 
     // -------------------------------------------- //
@@ -615,11 +616,11 @@ contract LendingMarketTest is Test {
     function test_updateLiquidityPoolLender() public {
         vm.startPrank(OWNER);
 
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
-        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER_1);
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
+        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LiquidityPoolLenderUpdated(address(liquidityPool), LENDER_2, LENDER_1);
+        emit LiquidityPoolLenderUpdated(address(liquidityPool), LENDER_2, LENDER);
         market.updateLiquidityPoolLender(address(liquidityPool), LENDER_2);
 
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER_2);
@@ -628,13 +629,13 @@ contract LendingMarketTest is Test {
     function test_updateLiquidityPoolLender_Revert_IfCallerNotOwner() public {
         vm.prank(ATTACKER);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
-        market.updateLiquidityPoolLender(address(liquidityPool), LENDER_1);
+        market.updateLiquidityPoolLender(address(liquidityPool), LENDER);
     }
 
     function test_updateLiquidityPoolLender_Revert_IfLiquidityPoolIsZeroAddress() public {
         vm.prank(OWNER);
         vm.expectRevert(Error.ZeroAddress.selector);
-        market.updateLiquidityPoolLender(address(0), LENDER_1);
+        market.updateLiquidityPoolLender(address(0), LENDER);
     }
 
     function test_updateLiquidityPoolLender_Revert_IfLenderIsZeroAddress() public {
@@ -645,9 +646,9 @@ contract LendingMarketTest is Test {
 
     function test_updateLiquidityPoolLender_Revert_IfLenderAlreadyConfigured() public {
         vm.startPrank(OWNER);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
         vm.expectRevert(Error.AlreadyConfigured.selector);
-        market.updateLiquidityPoolLender(address(liquidityPool), LENDER_1);
+        market.updateLiquidityPoolLender(address(liquidityPool), LENDER);
     }
 
     // -------------------------------------------- //
@@ -662,11 +663,11 @@ contract LendingMarketTest is Test {
     }
 
     function test_assignLiquidityPoolToCreditLine() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_1);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER);
 
         assertEq(market.getLiquidityPoolByCreditLine(address(creditLine)), address(0));
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(market));
         emit LiquidityPoolAssignedToCreditLine(address(creditLine), address(liquidityPool), address(0));
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
@@ -675,45 +676,45 @@ contract LendingMarketTest is Test {
     }
 
     function test_assignLiquidityPoolToCreditLine_Revert_IfContractIsPaused() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_1);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER);
 
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
     }
 
     function test_assignLiquidityPoolToCreditLine_Revert_IfCreditLineIsZeroAddress() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_1);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(Error.ZeroAddress.selector);
         market.assignLiquidityPoolToCreditLine(address(0), address(liquidityPool));
     }
 
     function test_assignLiquidityPoolToCreditLine_Revert_IfLiquidityPoolIsZeroAddress() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_1);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(Error.ZeroAddress.selector);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(0));
     }
 
     function test_assignLiquidityPoolToCreditLine_Revert_IfAlreadyAssigned() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_1);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER);
 
-        vm.startPrank(LENDER_1);
+        vm.startPrank(LENDER);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
         vm.expectRevert(Error.NotImplemented.selector);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
     }
 
     function test_assignLiquidityPoolToCreditLine_Revert_IfLenderMismatch() public {
-        registerCreditLineAndLiquidityPool(LENDER_1, LENDER_2);
+        registerCreditLineAndLiquidityPool(LENDER, LENDER_2);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(Error.Unauthorized.selector);
         market.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
     }
@@ -724,35 +725,36 @@ contract LendingMarketTest is Test {
 
     function test_takeLoan() public {
         configureMarket();
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
         uint256 totalBorrowAmount = BORROW_AMOUNT + terms.addonAmount;
         uint256 loanId = 0;
 
         token.mint(address(liquidityPool), BORROW_AMOUNT);
 
-        assertEq(token.balanceOf(address(liquidityPool)), BORROW_AMOUNT);
-        assertEq(token.balanceOf(BORROWER_1), 0);
-        assertEq(market.totalSupply(), 0);
+        uint256 totalSupply = market.totalSupply();
+        uint256 borrowerBalance = token.balanceOf(BORROWER);
+        uint256 liquidityPoolBefore = token.balanceOf(address(liquidityPool));
 
         vm.expectEmit(true, true, true, true, address(liquidityPool));
         emit OnBeforeLoanTakenCalled(loanId, address(creditLine));
         vm.expectEmit(true, true, true, true, address(liquidityPool));
         emit OnAfterLoanTakenCalled(loanId, address(creditLine));
         vm.expectEmit(true, true, true, true, address(market));
-        emit LoanTaken(loanId, BORROWER_1, totalBorrowAmount, terms.durationInPeriods);
+        emit LoanTaken(loanId, BORROWER, totalBorrowAmount, terms.durationInPeriods);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         assertEq(market.takeLoan(address(creditLine), BORROW_AMOUNT, terms.durationInPeriods), loanId);
 
         Loan.State memory loan = market.getLoanState(loanId);
 
-        assertEq(token.balanceOf(BORROWER_1), BORROW_AMOUNT);
-        assertEq(token.balanceOf(address(liquidityPool)), 0);
-        assertEq(market.ownerOf(loanId), LENDER_1);
-        assertEq(market.totalSupply(), 1);
+        assertEq(market.ownerOf(loanId), LENDER);
+        assertEq(market.totalSupply(), totalSupply + 1);
+        assertEq(token.balanceOf(BORROWER), borrowerBalance + BORROW_AMOUNT);
+        assertEq(token.balanceOf(address(liquidityPool)), liquidityPoolBefore - BORROW_AMOUNT);
 
         assertEq(loan.token, terms.token);
-        assertEq(loan.borrower, BORROWER_1);
+        assertEq(loan.borrower, BORROWER);
         assertEq(loan.treasury, terms.treasury);
         assertEq(loan.startTimestamp, block.timestamp);
         assertEq(loan.trackedTimestamp, block.timestamp);
@@ -772,49 +774,49 @@ contract LendingMarketTest is Test {
 
     function test_takeLoan_Revert_IfContractIsPaused() public {
         configureMarket();
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
 
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.takeLoan(address(creditLine), BORROW_AMOUNT, terms.durationInPeriods);
     }
 
     function test_takeLoan_Revert_IfBorrowAmountIsZero() public {
         configureMarket();
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(Error.InvalidAmount.selector);
         market.takeLoan(address(creditLine), 0, terms.durationInPeriods);
     }
 
     function test_takeLoan_Revert_IfCreditLineIsZeroAddress() public {
         configureMarket();
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(Error.ZeroAddress.selector);
         market.takeLoan(address(0), BORROW_AMOUNT, terms.durationInPeriods);
     }
 
     function test_takeLoan_Revert_IfCreditLineIsNotRegistered() public {
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(LendingMarket.CreditLineNotRegistered.selector);
         market.takeLoan(address(creditLine), BORROW_AMOUNT, terms.durationInPeriods);
     }
 
     function test_takeLoan_Revert_IfLiquidityPoolIsNotRegistered() public {
-        Loan.Terms memory terms = mockLoanTerms(BORROWER_1, BORROW_AMOUNT, false);
+        Loan.Terms memory terms = mockLoanTerms(BORROWER, BORROW_AMOUNT, false);
 
-        vm.prank(REGISTRY_1);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        vm.prank(OWNER);
+        market.registerCreditLine(LENDER, address(creditLine));
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(LendingMarket.LiquidityPoolNotRegistered.selector);
         market.takeLoan(address(creditLine), BORROW_AMOUNT, terms.durationInPeriods);
     }
@@ -826,14 +828,14 @@ contract LendingMarketTest is Test {
     function repayLoan(uint256 loanId, bool autoRepaymnet) private {
         Loan.State memory loan = market.getLoanState(loanId);
 
-        assertEq(market.ownerOf(loanId), LENDER_1);
+        assertEq(market.ownerOf(loanId), LENDER);
         assertEq(loan.trackedBorrowBalance >= 2, true);
 
         // Repayment mode
         if (autoRepaymnet) {
             vm.startPrank(address(liquidityPool));
         } else {
-            vm.startPrank(BORROWER_1);
+            vm.startPrank(BORROWER);
         }
 
         // Partial repayment
@@ -843,75 +845,75 @@ contract LendingMarketTest is Test {
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         uint256 repayAmount = outstandingBalance / 2;
         outstandingBalance -= repayAmount;
-        token.mint(BORROWER_1, outstandingBalance - token.balanceOf(BORROWER_1));
+        token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER));
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LoanRepayment(loanId, BORROWER_1, BORROWER_1, repayAmount, outstandingBalance);
+        emit LoanRepayment(loanId, BORROWER, BORROWER, repayAmount, outstandingBalance);
         market.repayLoan(loanId, repayAmount);
 
         uint256 newOutstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         assertEq(newOutstandingBalance, outstandingBalance);
-        assertEq(market.ownerOf(loanId), LENDER_1);
+        assertEq(market.ownerOf(loanId), LENDER);
 
         // Full repayment
 
         skip(loan.periodInSeconds * 3);
 
         outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
-        token.mint(BORROWER_1, outstandingBalance - token.balanceOf(BORROWER_1));
+        token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER));
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LoanRepayment(loanId, BORROWER_1, BORROWER_1, outstandingBalance, 0);
+        emit LoanRepayment(loanId, BORROWER, BORROWER, outstandingBalance, 0);
         market.repayLoan(loanId, outstandingBalance);
 
         newOutstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         assertEq(newOutstandingBalance, 0);
-        assertEq(market.ownerOf(loanId), BORROWER_1);
+        assertEq(market.ownerOf(loanId), BORROWER);
     }
 
     function test_repayLoan_IfLoanIsActive() public {
         configureMarket();
-        repayLoan(createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1), false);
+        repayLoan(createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1), false);
     }
 
     function test_repayLoan_IfLoanIsFrozen() public {
         configureMarket();
-        repayLoan(createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 1), false);
+        repayLoan(createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 1), false);
     }
 
     function test_repayLoan_IfLoanIsDefaulted() public {
         configureMarket();
-        repayLoan(createDefaultedLoan(BORROWER_1, BORROW_AMOUNT, false, 1), false);
+        repayLoan(createDefaultedLoan(BORROWER, BORROW_AMOUNT, false, 1), false);
     }
 
     function test_repayLoan_IfLoanIsActive_AutoRepayment() public {
         configureMarket();
-        repayLoan(createActiveLoan(BORROWER_1, BORROW_AMOUNT, true, 1), true);
+        repayLoan(createActiveLoan(BORROWER, BORROW_AMOUNT, true, 1), true);
     }
 
     function test_repayLoan_IfLoanIsFrozen_AutoRepayment() public {
         configureMarket();
-        repayLoan(createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, true, 1), true);
+        repayLoan(createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, true, 1), true);
     }
 
     function test_repayLoan_IfLoanIsDefaulted_AutoRepayment() public {
         configureMarket();
-        repayLoan(createDefaultedLoan(BORROWER_1, BORROW_AMOUNT, true, 1), true);
+        repayLoan(createDefaultedLoan(BORROWER, BORROW_AMOUNT, true, 1), true);
     }
 
     function test_repayLoan_IRepaymentAmountIsUint256Max() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.startPrank(BORROWER_1);
+        vm.startPrank(BORROWER);
 
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
         assertEq(outstandingBalance != 0, true);
 
-        token.mint(BORROWER_1, outstandingBalance - token.balanceOf(BORROWER_1));
+        token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER));
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LoanRepayment(loanId, BORROWER_1, BORROWER_1, outstandingBalance, 0);
+        emit LoanRepayment(loanId, BORROWER, BORROWER, outstandingBalance, 0);
         market.repayLoan(loanId, type(uint256).max);
 
         outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
@@ -920,13 +922,13 @@ contract LendingMarketTest is Test {
 
     function test_repayLoan_Revert_IfContractIsPaused() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         vm.startPrank(OWNER);
         market.pause();
 
-        vm.startPrank(BORROWER_1);
+        vm.startPrank(BORROWER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.repayLoan(loanId, loan.trackedBorrowBalance);
     }
@@ -934,35 +936,35 @@ contract LendingMarketTest is Test {
     function test_repayLoan_Revert_IfLoanNotExist() public {
         configureMarket();
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.repayLoan(LOAN_ID_NONEXISTENT, 1);
     }
 
     function test_repayLoan_Revert_IfLoanIsRepaid() public {
         configureMarket();
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.repayLoan(loanId, 1);
     }
 
     function test_repayLoan_Revert_IfRepayAmountIsZero() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(Error.InvalidAmount.selector);
         market.repayLoan(loanId, 0);
     }
 
     function test_repayLoan_Revert_IfAutoRepaymentIsNotAllowed() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
-        token.mint(BORROWER_1, outstandingBalance - token.balanceOf(BORROWER_1));
+        token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER));
 
         vm.prank(address(liquidityPool));
         vm.expectRevert(LendingMarket.AutoRepaymentNotAllowed.selector);
@@ -971,12 +973,12 @@ contract LendingMarketTest is Test {
 
     function test_repayLoan_Revert_IfRepayAmountIsGreaterThanBorrowAmount() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
         uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
-        token.mint(BORROWER_1, outstandingBalance - token.balanceOf(BORROWER_1) + 1);
+        token.mint(BORROWER, outstandingBalance - token.balanceOf(BORROWER) + 1);
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(Error.InvalidAmount.selector);
         market.repayLoan(loanId, outstandingBalance + 1);
     }
@@ -988,7 +990,7 @@ contract LendingMarketTest is Test {
     function test_revokeLoan() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 0);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 0);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 borrowerBalance = token.balanceOf(loan.borrower);
@@ -1016,7 +1018,7 @@ contract LendingMarketTest is Test {
     function test_revokeLoan_Revert_IfContractIsPaused() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         vm.startPrank(OWNER);
@@ -1030,7 +1032,7 @@ contract LendingMarketTest is Test {
     function test_revokeLoan_Revert_IfLoanNotExist() public {
         configureMarket();
 
-        vm.prank(BORROWER_1);
+        vm.prank(BORROWER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.revokeLoan(LOAN_ID_NONEXISTENT);
     }
@@ -1038,7 +1040,7 @@ contract LendingMarketTest is Test {
     function test_revokeLoan_Revert_IfRevocationIsProhibited() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
         assertEq(loan.trackedTimestamp, loan.startTimestamp);
 
@@ -1054,7 +1056,7 @@ contract LendingMarketTest is Test {
     function test_revokeLoan_Revert_IfRevocationPeriodHasPassed() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
         assertEq(loan.trackedTimestamp, loan.startTimestamp);
 
@@ -1071,7 +1073,7 @@ contract LendingMarketTest is Test {
 
     function test_freeze(address caller) private {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
         Loan.State memory loan = market.getLoanState(loanId);
         assertEq(loan.freezeTimestamp, 0);
@@ -1086,30 +1088,30 @@ contract LendingMarketTest is Test {
     }
 
     function test_freeze_IfLender() public {
-        test_freeze(LENDER_1);
+        test_freeze(LENDER);
     }
 
     function test_freeze_IfLenderAlias() public {
-        vm.prank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        test_freeze(LENDER_1_ALIAS);
+        vm.prank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
+        test_freeze(LENDER_ALIAS);
     }
 
     function test_freeze_Revert_IfContractIsPaused() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.freeze(loanId);
     }
 
     function test_freeze_Revert_IfCallerNotLender() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
@@ -1119,25 +1121,25 @@ contract LendingMarketTest is Test {
     function test_freeze_Revert_IfLoanNotExist() public {
         configureMarket();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.freeze(LOAN_ID_NONEXISTENT);
     }
 
     function test_freeze_Revert_IfLoanIsRepaid() public {
         configureMarket();
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.freeze(loanId);
     }
 
     function test_freeze_Revert_IfLoanIsFrozen() public {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyFrozen.selector);
         market.freeze(loanId);
     }
@@ -1148,7 +1150,7 @@ contract LendingMarketTest is Test {
 
     function test_unfreeze(address caller) private {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 0);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 0);
 
         Loan.State memory loan = market.getLoanState(loanId);
         assertEq(loan.freezeTimestamp != 0, true);
@@ -1161,18 +1163,18 @@ contract LendingMarketTest is Test {
     }
 
     function test_unfreeze_IfLender() public {
-        test_unfreeze(LENDER_1);
+        test_unfreeze(LENDER);
     }
 
     function test_unfreeze_IfLenderAlias() public {
-        vm.prank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        test_unfreeze(LENDER_1_ALIAS);
+        vm.prank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
+        test_unfreeze(LENDER_ALIAS);
     }
 
     function test_unfreeze_IfSamePeriod() public {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 0);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 0);
 
         Loan.State memory loan = market.getLoanState(loanId);
         Loan.Preview memory preview = market.getLoanPreview(loanId, 0);
@@ -1184,7 +1186,7 @@ contract LendingMarketTest is Test {
         // assertEq(loan.freezeTimestamp, currentTimestamp);
         // assertEq(loan.trackedTimestamp, currentTimestamp);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanUnfrozen(loanId);
         market.unfreeze(loanId);
@@ -1200,7 +1202,7 @@ contract LendingMarketTest is Test {
 
     function test_unfreeze_IfDifferentPeriod() public {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 0);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 0);
 
         Loan.State memory loan = market.getLoanState(loanId);
         Loan.Preview memory preview = market.getLoanPreview(loanId, 0);
@@ -1214,7 +1216,7 @@ contract LendingMarketTest is Test {
         uint256 skipPeriods = 2;
         skip(loan.periodInSeconds * skipPeriods);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanUnfrozen(loanId);
         market.unfreeze(loanId);
@@ -1230,19 +1232,19 @@ contract LendingMarketTest is Test {
 
     function test_unfreeze_Revert_IfContractIsPaused() public {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 1);
 
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.unfreeze(loanId);
     }
 
     function test_unfreeze_Revert_IfCallerNotLender() public {
         configureMarket();
-        uint256 loanId = createFrozenLoan(LENDER_1, BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createFrozenLoan(LENDER, BORROWER, BORROW_AMOUNT, false, 1);
 
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
@@ -1250,25 +1252,25 @@ contract LendingMarketTest is Test {
     }
 
     function test_unfreeze_Revert_IfLoanNotExist() public {
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.unfreeze(LOAN_ID_NONEXISTENT);
     }
 
     function test_unfreeze_Revert_IfLoanIsRepaid() public {
         configureMarket();
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.unfreeze(loanId);
     }
 
     function test_unfreeze_Revert_IfLoanNotFrozen() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotFrozen.selector);
         market.unfreeze(loanId);
     }
@@ -1280,7 +1282,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanDuration(address caller) private {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newDurationInPeriods = loan.durationInPeriods + 2;
@@ -1295,19 +1297,19 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanDuration_IfLender() public {
-        test_updateLoanDuration(LENDER_1);
+        test_updateLoanDuration(LENDER);
     }
 
     function test_updateLoanDuration_IfLenderAlias() public {
-        vm.prank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        test_updateLoanDuration(LENDER_1_ALIAS);
+        vm.prank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
+        test_updateLoanDuration(LENDER_ALIAS);
     }
 
     function test_updateLoanDuration_Revert_IfContractIsPaused() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         vm.prank(OWNER);
@@ -1315,7 +1317,7 @@ contract LendingMarketTest is Test {
 
         uint256 newDurationInPeriods = loan.durationInPeriods + 2;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.updateLoanDuration(loanId, newDurationInPeriods);
     }
@@ -1323,7 +1325,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanDuration_Revert_IfCallerNotLender() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newDurationInPeriods = loan.durationInPeriods + 2;
@@ -1334,7 +1336,7 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanDuration_Revert_IfLoanNotExist() public {
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.updateLoanDuration(LOAN_ID_NONEXISTENT, 100);
     }
@@ -1342,12 +1344,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanDuration_Revert_IfRepaidLoan() public {
         configureMarket();
 
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newDurationInPeriods = loan.durationInPeriods + 2;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.updateLoanDuration(loanId, newDurationInPeriods);
     }
@@ -1355,12 +1357,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanDuration_Revert_IfSameLoanDuration() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newDurationInPeriods = loan.durationInPeriods;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.InappropriateLoanDuration.selector);
         market.updateLoanDuration(loanId, newDurationInPeriods);
     }
@@ -1368,12 +1370,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanDuration_Revert_IfDecreasedLoanDuration() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newDurationInPeriods = loan.durationInPeriods - 1;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.InappropriateLoanDuration.selector);
         market.updateLoanDuration(loanId, newDurationInPeriods);
     }
@@ -1385,7 +1387,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRatePrimary(address caller) private {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 oldInterestRatePrimary = loan.interestRatePrimary;
@@ -1401,19 +1403,19 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanInterestRatePrimary_IfLender() public {
-        test_updateLoanInterestRatePrimary(LENDER_1);
+        test_updateLoanInterestRatePrimary(LENDER);
     }
 
     function test_updateLoanInterestRatePrimary_IfLenderAlias() public {
-        vm.prank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        test_updateLoanInterestRatePrimary(LENDER_1_ALIAS);
+        vm.prank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
+        test_updateLoanInterestRatePrimary(LENDER_ALIAS);
     }
 
     function test_updateLoanInterestRatePrimary_Revert_IfContractIsPaused() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRatePrimary = loan.interestRatePrimary - 1;
@@ -1421,7 +1423,7 @@ contract LendingMarketTest is Test {
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.updateLoanInterestRatePrimary(loanId, newInterestRatePrimary);
     }
@@ -1429,7 +1431,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRatePrimary_Revert_IfCallerNotLender() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRatePrimary = loan.interestRatePrimary - 1;
@@ -1440,7 +1442,7 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanInterestRatePrimary_Revert_IfLoanNotExist() public {
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.updateLoanInterestRatePrimary(LOAN_ID_NONEXISTENT, 100);
     }
@@ -1448,24 +1450,24 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRatePrimary_Revert_IfLoadIsRepaid() public {
         configureMarket();
 
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRatePrimary = loan.interestRatePrimary - 1;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.updateLoanInterestRatePrimary(loanId, newInterestRatePrimary);
     }
 
     function test_updateLoanInterestRatePrimary_Revert_IfIncreasedInterestRate() public {
         configureMarket();
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRatePrimary = loan.interestRatePrimary + 1;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.InappropriateInterestRate.selector);
         market.updateLoanInterestRatePrimary(loanId, newInterestRatePrimary);
     }
@@ -1477,7 +1479,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRateSecondary(address caller) private {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 oldInterestRateSecondary = loan.interestRateSecondary;
@@ -1493,19 +1495,19 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanInterestRateSecondary_IfLender() public {
-        test_updateLoanInterestRateSecondary(LENDER_1);
+        test_updateLoanInterestRateSecondary(LENDER);
     }
 
     function test_updateLoanInterestRateSecondary_IfLenderAlias() public {
-        vm.prank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        test_updateLoanInterestRateSecondary(LENDER_1_ALIAS);
+        vm.prank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
+        test_updateLoanInterestRateSecondary(LENDER_ALIAS);
     }
 
     function test_updateLoanInterestRateSecondary_Revert_IfContractIsPaused() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRateSecondary = loan.interestRateSecondary - 1;
@@ -1513,7 +1515,7 @@ contract LendingMarketTest is Test {
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         market.updateLoanInterestRateSecondary(loanId, newInterestRateSecondary);
     }
@@ -1521,7 +1523,7 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRateSecondary_Revert_IfCallerNotLender() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRateSecondary = loan.interestRateSecondary - 1;
@@ -1532,7 +1534,7 @@ contract LendingMarketTest is Test {
     }
 
     function test_updateLoanInterestRateSecondary_Revert_IfLoanNotExist() public {
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanNotExist.selector);
         market.updateLoanInterestRateSecondary(LOAN_ID_NONEXISTENT, 100);
     }
@@ -1540,12 +1542,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRateSecondary_Revert_IfLoadIsRepaid() public {
         configureMarket();
 
-        uint256 loanId = createRepaidLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createRepaidLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRateSecondary = loan.interestRateSecondary - 1;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.LoanAlreadyRepaid.selector);
         market.updateLoanInterestRateSecondary(loanId, newInterestRateSecondary);
     }
@@ -1553,12 +1555,12 @@ contract LendingMarketTest is Test {
     function test_updateLoanInterestRateSecondary_Revert_IfIncreasedInterestRate() public {
         configureMarket();
 
-        uint256 loanId = createActiveLoan(BORROWER_1, BORROW_AMOUNT, false, 1);
+        uint256 loanId = createActiveLoan(BORROWER, BORROW_AMOUNT, false, 1);
         Loan.State memory loan = market.getLoanState(loanId);
 
         uint256 newInterestRateSecondary = loan.interestRateSecondary + 1;
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(LendingMarket.InappropriateInterestRate.selector);
         market.updateLoanInterestRateSecondary(loanId, newInterestRateSecondary);
     }
@@ -1570,17 +1572,17 @@ contract LendingMarketTest is Test {
     function test_configureAlias() public {
         configureMarket();
 
-        vm.startPrank(LENDER_1);
+        vm.startPrank(LENDER);
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LenderAliasConfigured(LENDER_1, LENDER_1_ALIAS, true);
-        market.configureAlias(LENDER_1_ALIAS, true);
-        assertEq(market.hasAlias(LENDER_1, LENDER_1_ALIAS), true);
+        emit LenderAliasConfigured(LENDER, LENDER_ALIAS, true);
+        market.configureAlias(LENDER_ALIAS, true);
+        assertEq(market.hasAlias(LENDER, LENDER_ALIAS), true);
 
         vm.expectEmit(true, true, true, true, address(market));
-        emit LenderAliasConfigured(LENDER_1, LENDER_1_ALIAS, false);
-        market.configureAlias(LENDER_1_ALIAS, false);
-        assertEq(market.hasAlias(LENDER_1, LENDER_1_ALIAS), false);
+        emit LenderAliasConfigured(LENDER, LENDER_ALIAS, false);
+        market.configureAlias(LENDER_ALIAS, false);
+        assertEq(market.hasAlias(LENDER, LENDER_ALIAS), false);
     }
 
     function test_configureAlias_Revert_IfContractIsPaused() public {
@@ -1589,15 +1591,15 @@ contract LendingMarketTest is Test {
         vm.prank(OWNER);
         market.pause();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        market.configureAlias(LENDER_1_ALIAS, true);
+        market.configureAlias(LENDER_ALIAS, true);
     }
 
     function test_configureAlias_Revert_IfAliasIsZeroAddress() public {
         configureMarket();
 
-        vm.prank(LENDER_1);
+        vm.prank(LENDER);
         vm.expectRevert(Error.ZeroAddress.selector);
         market.configureAlias(address(0), true);
     }
@@ -1605,10 +1607,10 @@ contract LendingMarketTest is Test {
     function test_configureAlias_Revert_IfAliasIsAlreadyConfigured() public {
         configureMarket();
 
-        vm.startPrank(LENDER_1);
-        market.configureAlias(LENDER_1_ALIAS, true);
+        vm.startPrank(LENDER);
+        market.configureAlias(LENDER_ALIAS, true);
         vm.expectRevert(Error.AlreadyConfigured.selector);
-        market.configureAlias(LENDER_1_ALIAS, true);
+        market.configureAlias(LENDER_ALIAS, true);
     }
 
     // -------------------------------------------- //
@@ -1618,19 +1620,19 @@ contract LendingMarketTest is Test {
     function test_getCreditLineLender() public {
         assertEq(market.getCreditLineLender(address(creditLine)), address(0));
 
-        vm.prank(REGISTRY_1);
-        market.registerCreditLine(LENDER_1, address(creditLine));
+        vm.prank(OWNER);
+        market.registerCreditLine(LENDER, address(creditLine));
 
-        assertEq(market.getCreditLineLender(address(creditLine)), LENDER_1);
+        assertEq(market.getCreditLineLender(address(creditLine)), LENDER);
     }
 
     function test_getLiquidityPoolLender() public {
         assertEq(market.getLiquidityPoolLender(address(liquidityPool)), address(0));
 
-        vm.prank(REGISTRY_1);
-        market.registerLiquidityPool(LENDER_1, address(liquidityPool));
+        vm.prank(OWNER);
+        market.registerLiquidityPool(LENDER, address(liquidityPool));
 
-        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER_1);
+        assertEq(market.getLiquidityPoolLender(address(liquidityPool)), LENDER);
     }
 
     function test_calculatePeriodIndex() public {

--- a/test/LendingMarket.t.sol
+++ b/test/LendingMarket.t.sol
@@ -300,14 +300,19 @@ contract LendingMarketTest is Test {
         market.repayLoan(loanId, outstandingBalance);
     }
 
+    function defaultLoan(uint256 loanId) private {
+        Loan.State memory loan = market.getLoanState(loanId);
+        skip(loan.periodInSeconds * loan.durationInPeriods);
+    }
+
     function freezeLoan(address lender, uint256 loanId) private {
         vm.prank(lender);
         market.freeze(loanId);
     }
 
-    function defaultLoan(uint256 loanId) private {
-        Loan.State memory loan = market.getLoanState(loanId);
-        skip(loan.periodInSeconds * loan.durationInPeriods);
+    function unfreezeLoan(address lender, uint256 loanId) private {
+        vm.prank(lender);
+        market.unfreeze(loanId);
     }
 
     function createActiveLoan(address borrower, uint256 borrowAmount, bool autoRepayment, uint256 skipPeriods) private returns (uint256) {
@@ -1020,7 +1025,8 @@ contract LendingMarketTest is Test {
         bool autoRepayment = false;
         uint256 loanId = createLoan(BORROWER, BORROW_AMOUNT, autoRepayment);
 
-        token.mint(BORROWER, market.getLoanPreview(loanId, 0).outstandingBalance);
+        uint256 outstandingBalance = market.getLoanPreview(loanId, 0).outstandingBalance;
+        token.mint(BORROWER, outstandingBalance);
 
         vm.expectEmit(true, true, true, true, address(market));
         emit LoanRepayment(loanId, BORROWER, BORROWER, outstandingBalance, 0);

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -129,7 +129,7 @@ contract LendingMarketComplexTest is Test {
             borrowPolicy: ICreditLineConfigurable.BorrowPolicy.Keep,
             autoRepayment: false,
             expiration: type(uint32).max,
-            revokePeriods: 0
+            revocationPeriods: 0
         });
     }
 
@@ -154,8 +154,8 @@ contract LendingMarketComplexTest is Test {
             maxAddonFixedRate: type(uint32).max,
             minAddonPeriodRate: 0,
             maxAddonPeriodRate: type(uint32).max,
-            minRevokePeriods: 0,
-            maxRevokePeriods: type(uint16).max
+            minRevocationPeriods: 0,
+            maxRevocationPeriods: type(uint16).max
         });
     }
 

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -128,7 +128,8 @@ contract LendingMarketComplexTest is Test {
             interestFormula: scenario.interestFormula,
             borrowPolicy: ICreditLineConfigurable.BorrowPolicy.Keep,
             autoRepayment: false,
-            expiration: type(uint32).max
+            expiration: type(uint32).max,
+            revokePeriods: 0
         });
     }
 
@@ -153,7 +154,9 @@ contract LendingMarketComplexTest is Test {
             minAddonFixedRate: 0,
             maxAddonFixedRate: type(uint32).max,
             minAddonPeriodRate: 0,
-            maxAddonPeriodRate: type(uint32).max
+            maxAddonPeriodRate: type(uint32).max,
+            minRevokePeriods: 0,
+            maxRevokePeriods: type(uint16).max
         });
     }
 

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -150,7 +150,6 @@ contract LendingMarketComplexTest is Test {
             minInterestRateSecondary: 0,
             maxInterestRateSecondary: type(uint32).max,
             interestRateFactor: scenario.interestRateFactor,
-            addonRecipient: address(0),
             minAddonFixedRate: 0,
             maxAddonFixedRate: type(uint32).max,
             minAddonPeriodRate: 0,

--- a/test/credit-lines/CreditLineConfigurable.t.sol
+++ b/test/credit-lines/CreditLineConfigurable.t.sol
@@ -63,8 +63,8 @@ contract CreditLineConfigurableTest is Test {
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE = 50;
     uint32 private constant CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE = 10;
     uint32 private constant CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE = 50;
-    uint16 private constant CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS = 2;
-    uint16 private constant CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS = 4;
+    uint16 private constant CREDIT_LINE_CONFIG_MIN_REVOCATION_PERIODS = 2;
+    uint16 private constant CREDIT_LINE_CONFIG_MAX_REVOCATION_PERIODS = 4;
 
     uint32 private constant BORROWER_CONFIG_EXPIRATION = 1000;
     uint64 private constant BORROWER_CONFIG_MIN_BORROW_AMOUNT = 500;
@@ -75,7 +75,7 @@ contract CreditLineConfigurableTest is Test {
     uint32 private constant BORROWER_CONFIG_INTEREST_RATE_SECONDARY = 6;
     uint32 private constant BORROWER_CONFIG_ADDON_FIXED_RATE = 15;
     uint32 private constant BORROWER_CONFIG_ADDON_PERIOD_RATE = 20;
-    uint16 private constant BORROWER_CONFIG_REVOKE_PERIODS = 3;
+    uint16 private constant BORROWER_CONFIG_REVOCATION_PERIODS = 3;
     bool private constant BORROWER_CONFIG_AUTOREPAYMENT = true;
     Interest.Formula private constant BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND = Interest.Formula.Compound;
     ICreditLineConfigurable.BorrowPolicy private constant BORROWER_CONFIG_BORROW_POLICY_DECREASE =
@@ -139,7 +139,7 @@ contract CreditLineConfigurableTest is Test {
             uint256(config1.interestFormula) == uint256(config2.interestFormula) &&
             uint256(config1.borrowPolicy) == uint256(config2.borrowPolicy) &&
             config1.autoRepayment == config2.autoRepayment &&
-            config1.revokePeriods == config2.revokePeriods
+            config1.revocationPeriods == config2.revocationPeriods
         );
     }
 
@@ -163,8 +163,8 @@ contract CreditLineConfigurableTest is Test {
             config1.maxAddonFixedRate == config2.maxAddonFixedRate &&
             config1.minAddonPeriodRate == config2.minAddonPeriodRate &&
             config1.maxAddonPeriodRate == config2.maxAddonPeriodRate &&
-            config1.minRevokePeriods == config2.minRevokePeriods &&
-            config1.maxRevokePeriods == config2.maxRevokePeriods
+            config1.minRevocationPeriods == config2.minRevocationPeriods &&
+            config1.maxRevocationPeriods == config2.maxRevocationPeriods
         );
     }
 
@@ -188,8 +188,8 @@ contract CreditLineConfigurableTest is Test {
             config1.maxAddonFixedRate == config2.maxAddonFixedRate &&
             config1.minAddonPeriodRate == config2.minAddonPeriodRate &&
             config1.maxAddonPeriodRate == config2.maxAddonPeriodRate &&
-            config1.minRevokePeriods == config2.minRevokePeriods &&
-            config1.maxRevokePeriods == config2.maxRevokePeriods
+            config1.minRevocationPeriods == config2.minRevocationPeriods &&
+            config1.maxRevocationPeriods == config2.maxRevocationPeriods
         );
     }
 
@@ -211,7 +211,7 @@ contract CreditLineConfigurableTest is Test {
             interestFormula: BORROWER_CONFIG_INTEREST_FORMULA_COMPOUND,
             borrowPolicy: BORROWER_CONFIG_BORROW_POLICY_DECREASE,
             autoRepayment: BORROWER_CONFIG_AUTOREPAYMENT,
-            revokePeriods: BORROWER_CONFIG_REVOKE_PERIODS
+            revocationPeriods: BORROWER_CONFIG_REVOCATION_PERIODS
         });
     }
 
@@ -250,8 +250,8 @@ contract CreditLineConfigurableTest is Test {
             maxAddonFixedRate: CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE,
             minAddonPeriodRate: CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE,
             maxAddonPeriodRate: CREDIT_LINE_CONFIG_MAX_ADDON_PERIOD_RATE,
-            minRevokePeriods: CREDIT_LINE_CONFIG_MIN_REVOKE_PERIODS,
-            maxRevokePeriods: CREDIT_LINE_CONFIG_MAX_REVOKE_PERIODS
+            minRevocationPeriods: CREDIT_LINE_CONFIG_MIN_REVOCATION_PERIODS,
+            maxRevocationPeriods: CREDIT_LINE_CONFIG_MAX_REVOCATION_PERIODS
         });
     }
 
@@ -483,9 +483,9 @@ contract CreditLineConfigurableTest is Test {
         creditLine.configureCreditLine(config);
     }
 
-    function test_configureCreditLine_Revert_IfMinRevokePeriodsIsGreaterThanMaxRevokePeriods() public {
+    function test_configureCreditLine_Revert_IfMinRevocationPeriodsIsGreaterThanMaxRevocationPeriods() public {
         ICreditLineConfigurable.CreditLineConfig memory config = initCreditLineConfig();
-        config.minRevokePeriods = config.maxRevokePeriods + 1;
+        config.minRevocationPeriods = config.maxRevocationPeriods + 1;
 
         vm.prank(LENDER_1);
         vm.expectRevert(CreditLineConfigurable.InvalidCreditLineConfiguration.selector);
@@ -698,22 +698,22 @@ contract CreditLineConfigurableTest is Test {
         creditLine.configureBorrower(BORROWER_1, borrowerConfig);
     }
 
-    function test_configureBorrower_Revert_IfRevokePeriodsIsLessThanCreditLineMinRevokePeriods() public {
+    function test_configureBorrower_Revert_IfRevocationPeriodsIsLessThanCreditLineMinRevocationPeriods() public {
         ICreditLineConfigurable.CreditLineConfig memory creditLineConfig = configureCreditLine();
 
         ICreditLineConfigurable.BorrowerConfig memory borrowerConfig = initBorrowerConfig(block.timestamp);
-        borrowerConfig.revokePeriods = creditLineConfig.minRevokePeriods - 1;
+        borrowerConfig.revocationPeriods = creditLineConfig.minRevocationPeriods - 1;
 
         vm.prank(ADMIN);
         vm.expectRevert(CreditLineConfigurable.InvalidBorrowerConfiguration.selector);
         creditLine.configureBorrower(BORROWER_1, borrowerConfig);
     }
 
-    function test_configureBorrower_Revert_IfRevokePeriodsIsGreaterThanCreditLineMaxRevokePeriods() public {
+    function test_configureBorrower_Revert_IfRevocationPeriodsIsGreaterThanCreditLineMaxRevocationPeriods() public {
         ICreditLineConfigurable.CreditLineConfig memory creditLineConfig = configureCreditLine();
 
         ICreditLineConfigurable.BorrowerConfig memory borrowerConfig = initBorrowerConfig(block.timestamp);
-        borrowerConfig.revokePeriods = creditLineConfig.maxRevokePeriods + 1;
+        borrowerConfig.revocationPeriods = creditLineConfig.maxRevocationPeriods + 1;
 
         vm.prank(ADMIN);
         vm.expectRevert(CreditLineConfigurable.InvalidBorrowerConfiguration.selector);

--- a/test/credit-lines/CreditLineConfigurable.t.sol
+++ b/test/credit-lines/CreditLineConfigurable.t.sol
@@ -48,7 +48,6 @@ contract CreditLineConfigurableTest is Test {
     address private constant BORROWER_2 = address(bytes20(keccak256("borrower_2")));
     address private constant BORROWER_3 = address(bytes20(keccak256("borrower_3")));
     address private constant LOAN_TREASURY = address(bytes20(keccak256("loan_treasury")));
-    address private constant ADDON_RECIPIENT = address(bytes20(keccak256("addon_recipient")));
 
     uint64 private constant CREDIT_LINE_CONFIG_MIN_BORROW_AMOUNT = 400;
     uint64 private constant CREDIT_LINE_CONFIG_MAX_BORROW_AMOUNT = 900;
@@ -160,7 +159,6 @@ contract CreditLineConfigurableTest is Test {
             config1.minInterestRateSecondary == config2.minInterestRateSecondary &&
             config1.maxInterestRateSecondary == config2.maxInterestRateSecondary &&
             config1.interestRateFactor == config2.interestRateFactor &&
-            config1.addonRecipient == config2.addonRecipient &&
             config1.minAddonFixedRate == config2.minAddonFixedRate &&
             config1.maxAddonFixedRate == config2.maxAddonFixedRate &&
             config1.minAddonPeriodRate == config2.minAddonPeriodRate &&
@@ -186,7 +184,6 @@ contract CreditLineConfigurableTest is Test {
             config1.minInterestRateSecondary == config2.minInterestRateSecondary &&
             config1.maxInterestRateSecondary == config2.maxInterestRateSecondary &&
             config1.interestRateFactor == config2.interestRateFactor &&
-            config1.addonRecipient == config2.addonRecipient &&
             config1.minAddonFixedRate == config2.minAddonFixedRate &&
             config1.maxAddonFixedRate == config2.maxAddonFixedRate &&
             config1.minAddonPeriodRate == config2.minAddonPeriodRate &&
@@ -249,7 +246,6 @@ contract CreditLineConfigurableTest is Test {
             minInterestRateSecondary: CREDIT_LINE_CONFIG_MIN_INTEREST_RATE_SECONDARY,
             maxInterestRateSecondary: CREDIT_LINE_CONFIG_MAX_INTEREST_RATE_SECONDARY,
             interestRateFactor: CREDIT_LINE_CONFIG_INTEREST_RATE_FACTOR,
-            addonRecipient: ADDON_RECIPIENT,
             minAddonFixedRate: CREDIT_LINE_CONFIG_MIN_ADDON_FIXED_RATE,
             maxAddonFixedRate: CREDIT_LINE_CONFIG_MAX_ADDON_FIXED_RATE,
             minAddonPeriodRate: CREDIT_LINE_CONFIG_MIN_ADDON_PERIOD_RATE,
@@ -903,7 +899,6 @@ contract CreditLineConfigurableTest is Test {
         assertEq(uint256(terms.interestFormula), uint256(borrowerConfig.interestFormula));
         assertEq(terms.autoRepayment, borrowerConfig.autoRepayment);
 
-        assertEq(terms.addonRecipient, creditLineConfig.addonRecipient);
         assertEq(
             terms.addonAmount,
             creditLine.calculateAddonAmount(
@@ -926,26 +921,6 @@ contract CreditLineConfigurableTest is Test {
         ICreditLineConfigurable.BorrowerConfig memory borrowerConfig = initBorrowerConfig(block.timestamp);
         borrowerConfig.addonFixedRate = 0;
         borrowerConfig.addonPeriodRate = 0;
-
-        vm.prank(ADMIN);
-        creditLine.configureBorrower(BORROWER_1, borrowerConfig);
-
-        Loan.Terms memory terms = creditLine.determineLoanTerms(
-            BORROWER_1,
-            borrowerConfig.minBorrowAmount,
-            DURATION_IN_PERIODS
-        );
-        assertEq(terms.addonAmount, 0);
-    }
-
-    function test_determineLoanTerms_WithoutAddon_ZeroAddonRecipient() public {
-        ICreditLineConfigurable.CreditLineConfig memory creditLineConfig = configureCreditLine();
-        creditLineConfig.addonRecipient = address(0);
-
-        vm.prank(LENDER_1);
-        creditLine.configureCreditLine(creditLineConfig);
-
-        ICreditLineConfigurable.BorrowerConfig memory borrowerConfig = initBorrowerConfig(block.timestamp);
 
         vm.prank(ADMIN);
         creditLine.configureBorrower(BORROWER_1, borrowerConfig);

--- a/test/liquidity-pools/LiquidityPoolAccountable.t.sol
+++ b/test/liquidity-pools/LiquidityPoolAccountable.t.sol
@@ -107,7 +107,8 @@ contract LiquidityPoolAccountableTest is Test {
             trackedTimestamp: 0,
             initialBorrowAmount: 0,
             trackedBorrowBalance: 0,
-            autoRepayment: false
+            autoRepayment: false,
+            revokePeriods: 0
         });
     }
 

--- a/test/liquidity-pools/LiquidityPoolAccountable.t.sol
+++ b/test/liquidity-pools/LiquidityPoolAccountable.t.sol
@@ -16,6 +16,7 @@ import { ERC20Mock } from "src/mocks/ERC20Mock.sol";
 import { CreditLineMock } from "src/mocks/CreditLineMock.sol";
 import { LendingMarketMock } from "src/mocks/LendingMarketMock.sol";
 
+import { ILiquidityPoolAccountable } from "src/common/interfaces/ILiquidityPoolAccountable.sol";
 import { LiquidityPoolAccountable } from "src/liquidity-pools/LiquidityPoolAccountable.sol";
 
 /// @title LiquidityPoolAccountableTest contract
@@ -28,7 +29,8 @@ contract LiquidityPoolAccountableTest is Test {
 
     event AdminConfigured(address indexed account, bool adminStatus);
     event Deposit(address indexed creditLine, uint256 amount);
-    event Withdrawal(address indexed tokenSource, uint256 amount);
+    event Withdrawal(address indexed creditLine, uint256 borrowable, uint256 addons);
+    event Rescue(address indexed token, uint256 amount);
     event AutoRepayment(uint256 numberOfLoans);
     event RepayLoanCalled(uint256 indexed loanId, uint256 repayAmount);
 
@@ -54,6 +56,7 @@ contract LiquidityPoolAccountableTest is Test {
     uint64 private constant DEPOSIT_AMOUNT_1 = 100;
     uint64 private constant DEPOSIT_AMOUNT_2 = 200;
     uint64 private constant DEPOSIT_AMOUNT_3 = 300;
+    uint64 private constant ADDON_AMOUNT = 25;
 
     uint16 private constant KIND_1 = 1;
 
@@ -70,10 +73,10 @@ contract LiquidityPoolAccountableTest is Test {
         liquidityPool.initialize(address(lendingMarket), LENDER);
     }
 
-    function configureLender() private {
+    function configureLender(uint256 amount) private {
         vm.startPrank(LENDER);
-        token.mint(LENDER, DEPOSIT_AMOUNT_1);
-        token.approve(address(liquidityPool), DEPOSIT_AMOUNT_1);
+        token.mint(LENDER, amount);
+        token.approve(address(liquidityPool), amount);
         vm.stopPrank();
     }
 
@@ -242,11 +245,15 @@ contract LiquidityPoolAccountableTest is Test {
     // -------------------------------------------- //
 
     function test_deposit() public {
-        configureLender();
+        configureLender(DEPOSIT_AMOUNT_1);
 
         assertEq(token.balanceOf(address(liquidityPool)), 0);
         assertEq(token.allowance(address(liquidityPool), address(lendingMarket)), 0);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), 0);
+
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, 0);
+        assertEq(creditLineBalance.addons, 0);
 
         vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(liquidityPool));
@@ -255,7 +262,10 @@ contract LiquidityPoolAccountableTest is Test {
 
         assertEq(token.balanceOf(address(liquidityPool)), DEPOSIT_AMOUNT_1);
         assertEq(token.allowance(address(liquidityPool), address(lendingMarket)), type(uint256).max);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
     }
 
     function test_deposit_Revert_IfCallerNotOwner() public {
@@ -280,88 +290,113 @@ contract LiquidityPoolAccountableTest is Test {
     //  Test `withdraw` function                    //
     // -------------------------------------------- //
 
-    function test_withdraw_CreditLineBalance() public {
-        configureLender();
+    function prepareWithdraw() private returns (uint256, uint256) {
+        uint256 depositAmount = DEPOSIT_AMOUNT_1 + DEPOSIT_AMOUNT_2 + ADDON_AMOUNT;
+        configureLender(depositAmount);
 
-        vm.startPrank(LENDER);
+        Loan.State memory loan = initLoanState();
+        loan.initialBorrowAmount = DEPOSIT_AMOUNT_1 + ADDON_AMOUNT;
+        loan.addonAmount = ADDON_AMOUNT;
+        lendingMarket.mockLoanState(LOAN_ID_1, loan);
 
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
+        vm.prank(LENDER);
+        liquidityPool.deposit(address(creditLine), depositAmount);
 
-        assertEq(token.balanceOf(LENDER), 0);
-        assertEq(token.balanceOf(address(liquidityPool)), DEPOSIT_AMOUNT_1);
-        assertEq(liquidityPool.getTokenBalance(address(token)), DEPOSIT_AMOUNT_1);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        vm.prank(address(lendingMarket));
+        liquidityPool.onAfterLoanTaken(LOAN_ID_1, address(creditLine));
 
-        vm.expectEmit(true, true, true, true, address(liquidityPool));
-        emit Withdrawal(address(creditLine), DEPOSIT_AMOUNT_1 - 1);
-        liquidityPool.withdraw(address(creditLine), DEPOSIT_AMOUNT_1 - 1);
-
-        assertEq(token.balanceOf(LENDER), DEPOSIT_AMOUNT_1 - 1);
-        assertEq(token.balanceOf(address(liquidityPool)), 1);
-        assertEq(liquidityPool.getTokenBalance(address(token)), 1);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), 1);
+        return (DEPOSIT_AMOUNT_2, ADDON_AMOUNT);
     }
 
-    function test_withdraw_TokenBalance() public {
-        configureLender();
+    function test_withdraw() public {
+        (uint256 borrowable, uint256 addons) = prepareWithdraw();
 
-        vm.startPrank(LENDER);
-
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
-
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, borrowable);
+        assertEq(creditLineBalance.addons, addons);
         assertEq(token.balanceOf(LENDER), 0);
-        assertEq(token.balanceOf(address(liquidityPool)), DEPOSIT_AMOUNT_1);
-        assertEq(liquidityPool.getTokenBalance(address(token)), DEPOSIT_AMOUNT_1);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
 
+        vm.prank(LENDER);
         vm.expectEmit(true, true, true, true, address(liquidityPool));
-        emit Withdrawal(address(token), DEPOSIT_AMOUNT_1 - 1);
-        liquidityPool.withdraw(address(token), DEPOSIT_AMOUNT_1 - 1);
+        emit Withdrawal(address(creditLine), 0, 1);
+        liquidityPool.withdraw(address(creditLine), 0, 1);
 
-        assertEq(token.balanceOf(LENDER), DEPOSIT_AMOUNT_1 - 1);
-        assertEq(token.balanceOf(address(liquidityPool)), 1);
-        assertEq(liquidityPool.getTokenBalance(address(token)), 1);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, borrowable);
+        assertEq(creditLineBalance.addons, addons - 1);
+        assertEq(token.balanceOf(LENDER), 1);
+
+        vm.prank(LENDER);
+        vm.expectEmit(true, true, true, true, address(liquidityPool));
+        emit Withdrawal(address(creditLine), 1, 0);
+        liquidityPool.withdraw(address(creditLine), 1, 0);
+
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, borrowable - 1);
+        assertEq(creditLineBalance.addons, addons - 1);
+        assertEq(token.balanceOf(LENDER), 2);
     }
 
     function test_withdraw_Revert_IfCallerNotOwner() public {
+        (uint256 borrowable, uint256 addons) = prepareWithdraw();
         vm.prank(ATTACKER);
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
-        liquidityPool.withdraw(address(creditLine), DEPOSIT_AMOUNT_1);
+        liquidityPool.withdraw(address(creditLine), borrowable, addons);
     }
 
-    function test_withdraw_Revert_IfTokenSourceIsZeroAddress() public {
+    function test_withdraw_Revert_IfCreditLineIsZeroAddress() public {
+        (uint256 borrowable, uint256 addons) = prepareWithdraw();
         vm.prank(LENDER);
         vm.expectRevert(Error.ZeroAddress.selector);
-        liquidityPool.withdraw(address(0), DEPOSIT_AMOUNT_1);
+        liquidityPool.withdraw(address(0), borrowable, addons);
     }
 
     function test_withdraw_Revert_IfWithdrawAmountIsZero() public {
+        prepareWithdraw();
         vm.prank(LENDER);
         vm.expectRevert(Error.InvalidAmount.selector);
-        liquidityPool.withdraw(address(creditLine), 0);
+        liquidityPool.withdraw(address(creditLine), 0, 0);
     }
 
-    function test_withdraw_Revert_CreditLineBalance_InsufficientBalance() public {
-        configureLender();
-        vm.startPrank(LENDER);
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
-        vm.expectRevert(LiquidityPoolAccountable.InsufficientBalance.selector);
-        liquidityPool.withdraw(address(creditLine), DEPOSIT_AMOUNT_1 + 1);
-    }
-
-    function test_withdraw_Revert_TokenBalance_InsufficientBalance() public {
-        configureLender();
-        vm.startPrank(LENDER);
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
-        vm.expectRevert(LiquidityPoolAccountable.InsufficientBalance.selector);
-        liquidityPool.withdraw(address(token), DEPOSIT_AMOUNT_1 + 1);
-    }
-
-    function test_withdraw_Revert_ZeroBalance() public {
+    function test_withdraw_Revert_CreditLineBalance_InsufficientBalance_Borrowable() public {
+        (uint256 borrowable, uint256 addons) = prepareWithdraw();
         vm.prank(LENDER);
-        vm.expectRevert(LiquidityPoolAccountable.ZeroBalance.selector);
-        liquidityPool.withdraw(address(creditLine), DEPOSIT_AMOUNT_1);
+        vm.expectRevert(LiquidityPoolAccountable.InsufficientBalance.selector);
+        liquidityPool.withdraw(address(creditLine), borrowable + 1, addons);
+    }
+
+    function test_withdraw_Revert_CreditLineBalance_InsufficientBalance_Addons() public {
+        (uint256 borrowable, uint256 addons) = prepareWithdraw();
+        vm.prank(LENDER);
+        vm.expectRevert(LiquidityPoolAccountable.InsufficientBalance.selector);
+        liquidityPool.withdraw(address(creditLine), borrowable, addons + 1);
+    }
+
+    // -------------------------------------------- //
+    //  Test `rescue` function                      //
+    // -------------------------------------------- //
+
+    function test_rescue() public {
+        token.mint(address(liquidityPool), DEPOSIT_AMOUNT_1);
+
+        assertEq(token.balanceOf(LENDER), 0);
+        assertEq(token.balanceOf(address(liquidityPool)), DEPOSIT_AMOUNT_1);
+
+        vm.prank(LENDER);
+        vm.expectEmit(true, true, true, true, address(liquidityPool));
+        emit Rescue(address(token), DEPOSIT_AMOUNT_1);
+        liquidityPool.rescue(address(token), DEPOSIT_AMOUNT_1);
+
+        assertEq(token.balanceOf(LENDER), DEPOSIT_AMOUNT_1);
+        assertEq(token.balanceOf(address(liquidityPool)), 0);
+    }
+
+    function test_rescue_Revert_IfCallerNotOwner() public {
+        token.mint(address(liquidityPool), DEPOSIT_AMOUNT_1);
+        vm.prank(ATTACKER);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
+        liquidityPool.rescue(address(token), DEPOSIT_AMOUNT_1);
     }
 
     // -------------------------------------------- //
@@ -436,22 +471,29 @@ contract LiquidityPoolAccountableTest is Test {
     // -------------------------------------------- //
 
     function test_onAfterLoanTaken() public {
-        configureLender();
+        configureLender(DEPOSIT_AMOUNT_1);
+
         Loan.State memory loan = initLoanState();
         loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
+        loan.addonAmount = ADDON_AMOUNT;
         lendingMarket.mockLoanState(LOAN_ID_1, loan);
 
         vm.prank(LENDER);
         liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
 
         assertEq(liquidityPool.getCreditLine(LOAN_ID_1), address(0));
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
 
         vm.prank(address(lendingMarket));
         assertEq(liquidityPool.onAfterLoanTaken(LOAN_ID_1, address(creditLine)), true);
 
         assertEq(liquidityPool.getCreditLine(LOAN_ID_1), address(creditLine));
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), 0);
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, 0);
+        assertEq(creditLineBalance.addons, ADDON_AMOUNT);
     }
 
     function test_onAfterLoanTaken_Revert_IfContractIsPaused() public {
@@ -497,40 +539,55 @@ contract LiquidityPoolAccountableTest is Test {
     //  Test `onAfterLoanPayment` function          //
     // -------------------------------------------- //
 
-    function test_onAfterLoanPayment_CreditLineBalance() public {
-        configureLender();
-        Loan.State memory loan = initLoanState();
-        loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
-        lendingMarket.mockLoanState(LOAN_ID_1, loan);
+    function prepareRepayment() private {
+        configureLender(DEPOSIT_AMOUNT_1);
 
         vm.prank(LENDER);
         liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
 
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        Loan.State memory loan = initLoanState();
+        loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
+        loan.addonAmount = ADDON_AMOUNT;
+        lendingMarket.mockLoanState(LOAN_ID_1, loan);
+    }
 
-        vm.startPrank(address(lendingMarket));
+    function test_onAfterLoanPayment_CreditLineBalance() public {
+        prepareRepayment();
+
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
+
+        vm.prank(address(lendingMarket));
         assertEq(liquidityPool.onAfterLoanTaken(LOAN_ID_1, address(creditLine)), true);
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), 0);
+
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, 0);
+        assertEq(creditLineBalance.addons, ADDON_AMOUNT);
+
+        vm.prank(address(lendingMarket));
         assertEq(liquidityPool.onAfterLoanPayment(LOAN_ID_1, DEPOSIT_AMOUNT_1), true);
 
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, ADDON_AMOUNT);
     }
 
     function test_onAfterLoanPayment_NonCreditLineBalance() public {
-        configureLender();
-        Loan.State memory loan = initLoanState();
-        loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
-        lendingMarket.mockLoanState(LOAN_ID_1, loan);
+        prepareRepayment();
 
-        vm.prank(LENDER);
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
-
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
 
         vm.prank(address(lendingMarket));
         assertEq(liquidityPool.onAfterLoanPayment(LOAN_ID_NONEXISTENT, DEPOSIT_AMOUNT_1), true);
 
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1);
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
     }
 
     function test_onAfterLoanPayment_Revert_IfContractIsPaused() public {
@@ -552,24 +609,39 @@ contract LiquidityPoolAccountableTest is Test {
     //  Test view functions                         //
     // -------------------------------------------- //
 
-    function test_getTokenBalance() public {
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), 0);
-        assertEq(liquidityPool.getTokenBalance(address(token)), 0);
-        assertEq(liquidityPool.getTokenBalance(TOKEN_SOURCE_NONEXISTENT), 0);
+    function test_getCreditLineBalance() public {
+        configureLender(DEPOSIT_AMOUNT_1);
 
-        vm.startPrank(LENDER);
-        token.mint(LENDER, DEPOSIT_AMOUNT_1 + 1);
-        token.approve(address(liquidityPool), DEPOSIT_AMOUNT_1 + 1);
-        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1 + 1);
-        token.mint(address(liquidityPool), DEPOSIT_AMOUNT_1 + 2);
+        ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
+            liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, 0);
+        assertEq(creditLineBalance.addons, 0);
+        assertEq(token.balanceOf(address(liquidityPool)), 0);
 
-        assertEq(liquidityPool.getTokenBalance(address(creditLine)), DEPOSIT_AMOUNT_1 + 1);
-        assertEq(liquidityPool.getTokenBalance(address(token)), DEPOSIT_AMOUNT_1 * 2 + 3);
-        assertEq(liquidityPool.getTokenBalance(TOKEN_SOURCE_NONEXISTENT), 0);
+        vm.prank(LENDER);
+        liquidityPool.deposit(address(creditLine), DEPOSIT_AMOUNT_1);
+
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
+        assertEq(creditLineBalance.addons, 0);
+        assertEq(token.balanceOf(address(liquidityPool)), DEPOSIT_AMOUNT_1);
+
+        Loan.State memory loan = initLoanState();
+        loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
+        loan.addonAmount = ADDON_AMOUNT;
+        lendingMarket.mockLoanState(LOAN_ID_1, loan);
+
+        vm.prank(address(lendingMarket));
+        liquidityPool.onAfterLoanTaken(LOAN_ID_1, address(creditLine));
+
+        creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
+        assertEq(creditLineBalance.borrowable, 0);
+        assertEq(creditLineBalance.addons, ADDON_AMOUNT);
     }
 
     function test_getCreditLine() public {
-        configureLender();
+        configureLender(DEPOSIT_AMOUNT_1);
+
         Loan.State memory loan = initLoanState();
         loan.initialBorrowAmount = DEPOSIT_AMOUNT_1;
         lendingMarket.mockLoanState(LOAN_ID_1, loan);

--- a/test/liquidity-pools/LiquidityPoolAccountable.t.sol
+++ b/test/liquidity-pools/LiquidityPoolAccountable.t.sol
@@ -29,7 +29,7 @@ contract LiquidityPoolAccountableTest is Test {
 
     event AdminConfigured(address indexed account, bool adminStatus);
     event Deposit(address indexed creditLine, uint256 amount);
-    event Withdrawal(address indexed creditLine, uint256 borrowable, uint256 addons);
+    event Withdrawal(address indexed creditLine, uint256 borrowableAmount, uint256 addonAmount);
     event Rescue(address indexed token, uint256 amount);
     event AutoRepayment(uint256 numberOfLoans);
     event RepayLoanCalled(uint256 indexed loanId, uint256 repayAmount);

--- a/test/liquidity-pools/LiquidityPoolAccountable.t.sol
+++ b/test/liquidity-pools/LiquidityPoolAccountable.t.sol
@@ -111,7 +111,7 @@ contract LiquidityPoolAccountableTest is Test {
             initialBorrowAmount: 0,
             trackedBorrowBalance: 0,
             autoRepayment: false,
-            revokePeriods: 0,
+            revocationPeriods: 0,
             addonAmount: 0
         });
     }
@@ -606,34 +606,34 @@ contract LiquidityPoolAccountableTest is Test {
     }
 
     // -------------------------------------------- //
-    //  Test `onBeforeLoanRevoke` function          //
+    //  Test `onBeforeLoanRevocation` function      //
     // -------------------------------------------- //
 
-    function test_onBeforeLoanRevoke() public {
+    function test_onBeforeLoanRevocation() public {
         vm.prank(address(lendingMarket));
-        assertEq(liquidityPool.onBeforeLoanRevoke(LOAN_ID_1), true);
+        assertEq(liquidityPool.onBeforeLoanRevocation(LOAN_ID_1), true);
     }
 
-    function test_onBeforeLoanRevoke_Revert_IfContractIsPaused() public {
+    function test_onBeforeLoanRevocation_Revert_IfContractIsPaused() public {
         vm.prank(LENDER);
         liquidityPool.pause();
 
         vm.prank(address(lendingMarket));
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        liquidityPool.onBeforeLoanRevoke(LOAN_ID_1);
+        liquidityPool.onBeforeLoanRevocation(LOAN_ID_1);
     }
 
-    function test_onBeforeLoanRevoke_Revert_IfCallerNotMarket() public {
+    function test_onBeforeLoanRevocation_Revert_IfCallerNotMarket() public {
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
-        liquidityPool.onBeforeLoanRevoke(LOAN_ID_1);
+        liquidityPool.onBeforeLoanRevocation(LOAN_ID_1);
     }
 
     // -------------------------------------------- //
-    //  Test `onAfterLoanRevoke` function           //
+    //  Test `onAfterLoanRevocation` function       //
     // -------------------------------------------- //
 
-    function test_onAfterLoanRevoke_ExistentLoan() public {
+    function test_onAfterLoanRevocation_ExistentLoan() public {
         prepareRepayment();
 
         ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
@@ -649,14 +649,14 @@ contract LiquidityPoolAccountableTest is Test {
         assertEq(creditLineBalance.addons, ADDON_AMOUNT);
 
         vm.prank(address(lendingMarket));
-        assertEq(liquidityPool.onAfterLoanRevoke(LOAN_ID_1), true);
+        assertEq(liquidityPool.onAfterLoanRevocation(LOAN_ID_1), true);
 
         creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
         assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
         assertEq(creditLineBalance.addons, 0);
     }
 
-    function test_onAfterLoanRevoke_NonExistentLoan() public {
+    function test_onAfterLoanRevocation_NonExistentLoan() public {
         prepareRepayment();
 
         ILiquidityPoolAccountable.CreditLineBalance memory creditLineBalance =
@@ -665,26 +665,26 @@ contract LiquidityPoolAccountableTest is Test {
         assertEq(creditLineBalance.addons, 0);
 
         vm.prank(address(lendingMarket));
-        assertEq(liquidityPool.onAfterLoanRevoke(LOAN_ID_NONEXISTENT), true);
+        assertEq(liquidityPool.onAfterLoanRevocation(LOAN_ID_NONEXISTENT), true);
 
         creditLineBalance = liquidityPool.getCreditLineBalance(address(creditLine));
         assertEq(creditLineBalance.borrowable, DEPOSIT_AMOUNT_1);
         assertEq(creditLineBalance.addons, 0);
     }
 
-    function test_onAfterLoanRevoke_Revert_IfContractIsPaused() public {
+    function test_onAfterLoanRevocation_Revert_IfContractIsPaused() public {
         vm.prank(LENDER);
         liquidityPool.pause();
 
         vm.prank(address(lendingMarket));
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        liquidityPool.onAfterLoanRevoke(LOAN_ID_1);
+        liquidityPool.onAfterLoanRevocation(LOAN_ID_1);
     }
 
-    function test_onAfterLoanRevoke_Revert_IfCallerNotMarket() public {
+    function test_onAfterLoanRevocation_Revert_IfCallerNotMarket() public {
         vm.prank(ATTACKER);
         vm.expectRevert(Error.Unauthorized.selector);
-        liquidityPool.onAfterLoanRevoke(LOAN_ID_1);
+        liquidityPool.onAfterLoanRevocation(LOAN_ID_1);
     }
 
     // -------------------------------------------- //

--- a/test/liquidity-pools/LiquidityPoolAccountable.t.sol
+++ b/test/liquidity-pools/LiquidityPoolAccountable.t.sol
@@ -108,7 +108,8 @@ contract LiquidityPoolAccountableTest is Test {
             initialBorrowAmount: 0,
             trackedBorrowBalance: 0,
             autoRepayment: false,
-            revokePeriods: 0
+            revokePeriods: 0,
+            addonAmount: 0
         });
     }
 

--- a/test/mocks/CreditLineMock.t.sol
+++ b/test/mocks/CreditLineMock.t.sol
@@ -28,12 +28,12 @@ contract CreditLineMockTest is Test {
     address private constant TERMS_TOKEN = address(bytes20(keccak256("token")));
     address private constant TERMS_TREASURY = address(bytes20(keccak256("treasury")));
 
-    uint16 private constant TERMS_REVOKE_PERIODS = 50;
     uint32 private constant TERMS_PERIOD_IN_SECONDS = 100;
     uint32 private constant TERMS_DURATION_IN_PERIODS = 200;
     uint32 private constant TERMS_INTEREST_RATE_FACTOR = 300;
     uint32 private constant TERMS_INTEREST_RATE_PRIMARY = 400;
     uint32 private constant TERMS_INTEREST_RATE_SECONDARY = 500;
+    uint16 private constant TERMS_REVOCATION_PERIODS = 25;
     uint32 private constant TERMS_ADDON_AMOUNT = 600;
 
     Interest.Formula private constant TERMS_INTEREST_FORMULA = Interest.Formula.Compound;
@@ -63,7 +63,7 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRateSecondary, 0);
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
         assertEq(terms.autoRepayment, false);
-        assertEq(terms.revokePeriods, 0);
+        assertEq(terms.revocationPeriods, 0);
         assertEq(terms.addonAmount, 0);
 
         mock.mockLoanTerms(
@@ -79,7 +79,7 @@ contract CreditLineMockTest is Test {
                 interestRateSecondary: TERMS_INTEREST_RATE_SECONDARY,
                 interestFormula: TERMS_INTEREST_FORMULA,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
-                revokePeriods: TERMS_REVOKE_PERIODS,
+                revocationPeriods: TERMS_REVOCATION_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
             })
         );
@@ -95,7 +95,7 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRateSecondary, TERMS_INTEREST_RATE_SECONDARY);
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
-        assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
+        assertEq(terms.revocationPeriods, TERMS_REVOCATION_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);
     }
 
@@ -111,7 +111,7 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRateSecondary, 0);
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
         assertEq(terms.autoRepayment, false);
-        assertEq(terms.revokePeriods, 0);
+        assertEq(terms.revocationPeriods, 0);
         assertEq(terms.addonAmount, 0);
 
         mock.mockLoanTerms(
@@ -127,7 +127,7 @@ contract CreditLineMockTest is Test {
                 interestRateSecondary: TERMS_INTEREST_RATE_SECONDARY,
                 interestFormula: TERMS_INTEREST_FORMULA,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
-                revokePeriods: TERMS_REVOKE_PERIODS,
+                revocationPeriods: TERMS_REVOCATION_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
             })
         );
@@ -143,7 +143,7 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRateSecondary, TERMS_INTEREST_RATE_SECONDARY);
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
-        assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
+        assertEq(terms.revocationPeriods, TERMS_REVOCATION_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);
     }
 

--- a/test/mocks/CreditLineMock.t.sol
+++ b/test/mocks/CreditLineMock.t.sol
@@ -29,6 +29,7 @@ contract CreditLineMockTest is Test {
     address private constant TERMS_TREASURY = address(bytes20(keccak256("treasury")));
     address private constant TERMS_ADDON_RECIPIENT = address(bytes20(keccak256("addon")));
 
+    uint16 private constant TERMS_REVOKE_PERIODS = 50;
     uint32 private constant TERMS_PERIOD_IN_SECONDS = 100;
     uint32 private constant TERMS_DURATION_IN_PERIODS = 200;
     uint32 private constant TERMS_INTEREST_RATE_FACTOR = 300;
@@ -64,6 +65,7 @@ contract CreditLineMockTest is Test {
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
         assertEq(terms.addonRecipient, address(0));
         assertEq(terms.autoRepayment, false);
+        assertEq(terms.revokePeriods, 0);
         assertEq(terms.addonAmount, 0);
 
         mock.mockLoanTerms(
@@ -80,6 +82,7 @@ contract CreditLineMockTest is Test {
                 interestFormula: TERMS_INTEREST_FORMULA,
                 addonRecipient: TERMS_ADDON_RECIPIENT,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
+                revokePeriods: TERMS_REVOKE_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
             })
         );
@@ -96,6 +99,7 @@ contract CreditLineMockTest is Test {
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
         assertEq(terms.addonRecipient, TERMS_ADDON_RECIPIENT);
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
+        assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);
     }
 
@@ -112,6 +116,7 @@ contract CreditLineMockTest is Test {
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
         assertEq(terms.addonRecipient, address(0));
         assertEq(terms.autoRepayment, false);
+        assertEq(terms.revokePeriods, 0);
         assertEq(terms.addonAmount, 0);
 
         mock.mockLoanTerms(
@@ -128,6 +133,7 @@ contract CreditLineMockTest is Test {
                 interestFormula: TERMS_INTEREST_FORMULA,
                 addonRecipient: TERMS_ADDON_RECIPIENT,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
+                revokePeriods: TERMS_REVOKE_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
             })
         );
@@ -144,6 +150,7 @@ contract CreditLineMockTest is Test {
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
         assertEq(terms.addonRecipient, TERMS_ADDON_RECIPIENT);
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
+        assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);
     }
 

--- a/test/mocks/CreditLineMock.t.sol
+++ b/test/mocks/CreditLineMock.t.sol
@@ -27,7 +27,6 @@ contract CreditLineMockTest is Test {
 
     address private constant TERMS_TOKEN = address(bytes20(keccak256("token")));
     address private constant TERMS_TREASURY = address(bytes20(keccak256("treasury")));
-    address private constant TERMS_ADDON_RECIPIENT = address(bytes20(keccak256("addon")));
 
     uint16 private constant TERMS_REVOKE_PERIODS = 50;
     uint32 private constant TERMS_PERIOD_IN_SECONDS = 100;
@@ -63,7 +62,6 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRatePrimary, 0);
         assertEq(terms.interestRateSecondary, 0);
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
-        assertEq(terms.addonRecipient, address(0));
         assertEq(terms.autoRepayment, false);
         assertEq(terms.revokePeriods, 0);
         assertEq(terms.addonAmount, 0);
@@ -80,7 +78,6 @@ contract CreditLineMockTest is Test {
                 interestRatePrimary: TERMS_INTEREST_RATE_PRIMARY,
                 interestRateSecondary: TERMS_INTEREST_RATE_SECONDARY,
                 interestFormula: TERMS_INTEREST_FORMULA,
-                addonRecipient: TERMS_ADDON_RECIPIENT,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
                 revokePeriods: TERMS_REVOKE_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
@@ -97,7 +94,6 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRatePrimary, TERMS_INTEREST_RATE_PRIMARY);
         assertEq(terms.interestRateSecondary, TERMS_INTEREST_RATE_SECONDARY);
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
-        assertEq(terms.addonRecipient, TERMS_ADDON_RECIPIENT);
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
         assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);
@@ -114,7 +110,6 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRatePrimary, 0);
         assertEq(terms.interestRateSecondary, 0);
         assertEq(uint256(terms.interestFormula), uint256(Interest.Formula.Simple));
-        assertEq(terms.addonRecipient, address(0));
         assertEq(terms.autoRepayment, false);
         assertEq(terms.revokePeriods, 0);
         assertEq(terms.addonAmount, 0);
@@ -131,7 +126,6 @@ contract CreditLineMockTest is Test {
                 interestRatePrimary: TERMS_INTEREST_RATE_PRIMARY,
                 interestRateSecondary: TERMS_INTEREST_RATE_SECONDARY,
                 interestFormula: TERMS_INTEREST_FORMULA,
-                addonRecipient: TERMS_ADDON_RECIPIENT,
                 autoRepayment: TERMS_AUTO_REPAYMENT,
                 revokePeriods: TERMS_REVOKE_PERIODS,
                 addonAmount: TERMS_ADDON_AMOUNT
@@ -148,7 +142,6 @@ contract CreditLineMockTest is Test {
         assertEq(terms.interestRatePrimary, TERMS_INTEREST_RATE_PRIMARY);
         assertEq(terms.interestRateSecondary, TERMS_INTEREST_RATE_SECONDARY);
         assertEq(uint256(terms.interestFormula), uint256(TERMS_INTEREST_FORMULA));
-        assertEq(terms.addonRecipient, TERMS_ADDON_RECIPIENT);
         assertEq(terms.autoRepayment, TERMS_AUTO_REPAYMENT);
         assertEq(terms.revokePeriods, TERMS_REVOKE_PERIODS);
         assertEq(terms.addonAmount, TERMS_ADDON_AMOUNT);

--- a/test/mocks/LendingMarketMock.t.sol
+++ b/test/mocks/LendingMarketMock.t.sol
@@ -55,6 +55,7 @@ contract LendingMarketMockTest is Test {
     uint32 private constant STATE_TRACKED_TIMESTAMP = 800;
     uint64 private constant STATE_INITIAL_BORROW_AMOUNT = 900;
     uint64 private constant STATE_TRACKED_BORROW_BALANCE = 1000;
+    uint64 private constant STATE_ADDON_AMOUNT = 1100;
     bool private constant STATE_AUTO_REPAYMENT = true;
 
     uint256 private constant UPDATE_LOAN_DURATION = 100;
@@ -176,6 +177,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.trackedBorrowBalance, 0);
         assertEq(loan.autoRepayment, false);
         assertEq(loan.revokePeriods, 0);
+        assertEq(loan.addonAmount, 0);
 
         mock.mockLoanState(
             1,
@@ -195,7 +197,8 @@ contract LendingMarketMockTest is Test {
                 initialBorrowAmount: STATE_INITIAL_BORROW_AMOUNT,
                 trackedBorrowBalance: STATE_TRACKED_BORROW_BALANCE,
                 autoRepayment: STATE_AUTO_REPAYMENT,
-                revokePeriods: STATE_REVOKE_PERIODS
+                revokePeriods: STATE_REVOKE_PERIODS,
+                addonAmount: STATE_ADDON_AMOUNT
             })
         );
 
@@ -217,6 +220,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.trackedBorrowBalance, STATE_TRACKED_BORROW_BALANCE);
         assertEq(loan.autoRepayment, STATE_AUTO_REPAYMENT);
         assertEq(loan.revokePeriods, STATE_REVOKE_PERIODS);
+        assertEq(loan.addonAmount, STATE_ADDON_AMOUNT);
     }
 
     function test_getLoanPreview() public {

--- a/test/mocks/LendingMarketMock.t.sol
+++ b/test/mocks/LendingMarketMock.t.sol
@@ -43,6 +43,7 @@ contract LendingMarketMockTest is Test {
     uint256 private constant REPAY_AMOUNT = 200;
     uint256 private constant LOAN_ID = 1;
 
+    uint16 private constant STATE_REVOKE_PERIODS = 10;
     uint32 private constant STATE_PERIOD_IN_SECONDS = 100;
     uint32 private constant STATE_DURATION_IN_PERIODS = 200;
     uint32 private constant STATE_INTEREST_RATE_FACTOR = 300;
@@ -174,6 +175,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.initialBorrowAmount, 0);
         assertEq(loan.trackedBorrowBalance, 0);
         assertEq(loan.autoRepayment, false);
+        assertEq(loan.revokePeriods, 0);
 
         mock.mockLoanState(
             1,
@@ -192,7 +194,8 @@ contract LendingMarketMockTest is Test {
                 trackedTimestamp: STATE_TRACKED_TIMESTAMP,
                 initialBorrowAmount: STATE_INITIAL_BORROW_AMOUNT,
                 trackedBorrowBalance: STATE_TRACKED_BORROW_BALANCE,
-                autoRepayment: STATE_AUTO_REPAYMENT
+                autoRepayment: STATE_AUTO_REPAYMENT,
+                revokePeriods: STATE_REVOKE_PERIODS
             })
         );
 
@@ -213,6 +216,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.initialBorrowAmount, STATE_INITIAL_BORROW_AMOUNT);
         assertEq(loan.trackedBorrowBalance, STATE_TRACKED_BORROW_BALANCE);
         assertEq(loan.autoRepayment, STATE_AUTO_REPAYMENT);
+        assertEq(loan.revokePeriods, STATE_REVOKE_PERIODS);
     }
 
     function test_getLoanPreview() public {

--- a/test/mocks/LendingMarketMock.t.sol
+++ b/test/mocks/LendingMarketMock.t.sol
@@ -86,6 +86,11 @@ contract LendingMarketMockTest is Test {
         mock.repayLoan(LOAN_ID, REPAY_AMOUNT);
     }
 
+    function test_revokeLoan() public {
+        vm.expectRevert(Error.NotImplemented.selector);
+        mock.revokeLoan(LOAN_ID);
+    }
+
     function test_freeze() public {
         vm.expectRevert(Error.NotImplemented.selector);
         mock.freeze(LOAN_ID);

--- a/test/mocks/LendingMarketMock.t.sol
+++ b/test/mocks/LendingMarketMock.t.sol
@@ -43,7 +43,7 @@ contract LendingMarketMockTest is Test {
     uint256 private constant REPAY_AMOUNT = 200;
     uint256 private constant LOAN_ID = 1;
 
-    uint16 private constant STATE_REVOKE_PERIODS = 10;
+    uint16 private constant STATE_REVOCATION_PERIODS = 10;
     uint32 private constant STATE_PERIOD_IN_SECONDS = 100;
     uint32 private constant STATE_DURATION_IN_PERIODS = 200;
     uint32 private constant STATE_INTEREST_RATE_FACTOR = 300;
@@ -181,7 +181,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.initialBorrowAmount, 0);
         assertEq(loan.trackedBorrowBalance, 0);
         assertEq(loan.autoRepayment, false);
-        assertEq(loan.revokePeriods, 0);
+        assertEq(loan.revocationPeriods, 0);
         assertEq(loan.addonAmount, 0);
 
         mock.mockLoanState(
@@ -202,7 +202,7 @@ contract LendingMarketMockTest is Test {
                 initialBorrowAmount: STATE_INITIAL_BORROW_AMOUNT,
                 trackedBorrowBalance: STATE_TRACKED_BORROW_BALANCE,
                 autoRepayment: STATE_AUTO_REPAYMENT,
-                revokePeriods: STATE_REVOKE_PERIODS,
+                revocationPeriods: STATE_REVOCATION_PERIODS,
                 addonAmount: STATE_ADDON_AMOUNT
             })
         );
@@ -224,7 +224,7 @@ contract LendingMarketMockTest is Test {
         assertEq(loan.initialBorrowAmount, STATE_INITIAL_BORROW_AMOUNT);
         assertEq(loan.trackedBorrowBalance, STATE_TRACKED_BORROW_BALANCE);
         assertEq(loan.autoRepayment, STATE_AUTO_REPAYMENT);
-        assertEq(loan.revokePeriods, STATE_REVOKE_PERIODS);
+        assertEq(loan.revocationPeriods, STATE_REVOCATION_PERIODS);
         assertEq(loan.addonAmount, STATE_ADDON_AMOUNT);
     }
 

--- a/test/mocks/LiquidityPoolMock.t.sol
+++ b/test/mocks/LiquidityPoolMock.t.sol
@@ -24,8 +24,8 @@ contract LiquidityPoolMockTest is Test {
     event OnBeforeLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
 
-    event OnBeforeLoanRevokeCalled(uint256 indexed loanId);
-    event OnAfterLoanRevokeCalled(uint256 indexed loanId);
+    event OnBeforeLoanRevocationCalled(uint256 indexed loanId);
+    event OnAfterLoanRevocationCalled(uint256 indexed loanId);
 
     // -------------------------------------------- //
     //  Storage variables                           //
@@ -105,31 +105,31 @@ contract LiquidityPoolMockTest is Test {
         assertEq(result, true);
     }
 
-    function test_onBeforeLoanRevoke() public {
+    function test_onBeforeLoanRevocation() public {
         vm.expectEmit(true, true, true, true, address(mock));
-        emit OnBeforeLoanRevokeCalled(LOAN_ID);
-        bool result = mock.onBeforeLoanRevoke(LOAN_ID);
+        emit OnBeforeLoanRevocationCalled(LOAN_ID);
+        bool result = mock.onBeforeLoanRevocation(LOAN_ID);
         assertEq(result, false);
 
-        mock.mockOnBeforeLoanRevokeResult(true);
+        mock.mockOnBeforeLoanRevocationResult(true);
 
         vm.expectEmit(true, true, true, true, address(mock));
-        emit OnBeforeLoanRevokeCalled(LOAN_ID);
-        result = mock.onBeforeLoanRevoke(LOAN_ID);
+        emit OnBeforeLoanRevocationCalled(LOAN_ID);
+        result = mock.onBeforeLoanRevocation(LOAN_ID);
         assertEq(result, true);
     }
 
-    function test_onAfterLoanRevoke() public {
+    function test_onAfterLoanRevocation() public {
         vm.expectEmit(true, true, true, true, address(mock));
-        emit OnAfterLoanRevokeCalled(LOAN_ID);
-        bool result = mock.onAfterLoanRevoke(LOAN_ID);
+        emit OnAfterLoanRevocationCalled(LOAN_ID);
+        bool result = mock.onAfterLoanRevocation(LOAN_ID);
         assertEq(result, false);
 
-        mock.mockOnAfterLoanRevokeResult(true);
+        mock.mockOnAfterLoanRevocationResult(true);
 
         vm.expectEmit(true, true, true, true, address(mock));
-        emit OnAfterLoanRevokeCalled(LOAN_ID);
-        result = mock.onAfterLoanRevoke(LOAN_ID);
+        emit OnAfterLoanRevocationCalled(LOAN_ID);
+        result = mock.onAfterLoanRevocation(LOAN_ID);
         assertEq(result, true);
     }
 

--- a/test/mocks/LiquidityPoolMock.t.sol
+++ b/test/mocks/LiquidityPoolMock.t.sol
@@ -24,6 +24,9 @@ contract LiquidityPoolMockTest is Test {
     event OnBeforeLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repayAmount);
 
+    event OnBeforeLoanRevokeCalled(uint256 indexed loanId);
+    event OnAfterLoanRevokeCalled(uint256 indexed loanId);
+
     // -------------------------------------------- //
     //  Storage variables                           //
     // -------------------------------------------- //
@@ -99,6 +102,34 @@ contract LiquidityPoolMockTest is Test {
         vm.expectEmit(true, true, true, true, address(mock));
         emit OnAfterLoanPaymentCalled(LOAN_ID, REPAY_AMOUNT);
         result = mock.onAfterLoanPayment(LOAN_ID, REPAY_AMOUNT);
+        assertEq(result, true);
+    }
+
+    function test_onBeforeLoanRevoke() public {
+        vm.expectEmit(true, true, true, true, address(mock));
+        emit OnBeforeLoanRevokeCalled(LOAN_ID);
+        bool result = mock.onBeforeLoanRevoke(LOAN_ID);
+        assertEq(result, false);
+
+        mock.mockOnBeforeLoanRevokeResult(true);
+
+        vm.expectEmit(true, true, true, true, address(mock));
+        emit OnBeforeLoanRevokeCalled(LOAN_ID);
+        result = mock.onBeforeLoanRevoke(LOAN_ID);
+        assertEq(result, true);
+    }
+
+    function test_onAfterLoanRevoke() public {
+        vm.expectEmit(true, true, true, true, address(mock));
+        emit OnAfterLoanRevokeCalled(LOAN_ID);
+        bool result = mock.onAfterLoanRevoke(LOAN_ID);
+        assertEq(result, false);
+
+        mock.mockOnAfterLoanRevokeResult(true);
+
+        vm.expectEmit(true, true, true, true, address(mock));
+        emit OnAfterLoanRevokeCalled(LOAN_ID);
+        result = mock.onAfterLoanRevoke(LOAN_ID);
         assertEq(result, true);
     }
 


### PR DESCRIPTION
## Logic changes

1. The new `revokeLoan()` function has been added to the lending market contract to revoke loans. This function can only be called by the borrower before the revocation period is over and if there have been no repayments for the specific loan. The revocation period is configured in loan periods and for each borrower separately.
```Solidity
    /// @dev Revokes a loan.
    /// @param loanId The unique identifier of the loan to revoke.
    function revokeLoan(uint256 loanId) external;
```
2. The new `LoanRevoked()` event is added to the lending market contract and is emitted when the loan is revoked. 
```Solidity
    /// @dev Emitted when a loan is revoked.
    /// @param loanId The unique identifier of the loan.
    event LoanRevoked(uint256 indexed loanId);
```
3. The new error types are added to the lending market contract and can be thrown on loan revocation operations.
```Solidity
    /// @dev Thrown when the revocation period has passed.
    error RevocationPeriodHasPassed();
    /// @dev Thrown when loan revocation is prohibited.
    error RevocationIsProhibited();
```
4. The process of withdrawing tokens from the liquidity pool contract is divided into two separate functions `withdraw()` and `rescue()`. Each function emits its own event.
```Solidity
    /// @dev Emitted when tokens are withdrawn from the liquidity pool.
    /// @param creditLine The address of the credit line.
    /// @param borrowableAmount The amount of tokens withdrawn from the borrowable balance.
    /// @param addonAmount The amount of tokens withdrawn from the addons balance.
    event Withdrawal(address indexed creditLine, uint256 borrowableAmount, uint256 addonAmount);

    /// @dev Emitted when tokens are rescued from the liquidity pool.
    /// @param token The address of the token rescued.
    /// @param amount The amount of tokens rescued.
    event Rescue(address indexed token, uint256 amount);

    /// @dev Withdraws tokens from the liquidity pool.
    /// @param creditLine The address of the credit line.
    /// @param borrowableAmount The amount of tokens to withdraw from the borrowable balance.
    /// @param addonAmount The amount of tokens to withdraw from the addons balance.
    function withdraw(address creditLine, uint256 borrowableAmount, uint256 addonAmount) external;

    /// @dev Rescues tokens from the liquidity pool.
    /// @param token The address of the token to rescue.
    /// @param amount The amount of tokens to rescue.
    function rescue(address token, uint256 amount) external;
```
5. The new function getCreditLineBalance() has been added to check the balance of a specific credit line, which consists of the `borrowable` and `addition` sub-balances.
```Solidity
    /// @dev A struct that defines the credit line balance.
    struct CreditLineBalance {
        uint64 borrowable; // The amount of tokens that can be borrowed.
        uint64 addons;       // The amount of tokens that are locked as addons.
    }

    /// @dev Retrieves the token balance of the credit line.
    /// @param creditLine The address of the credit line.
    /// @return The token balance of the token source.
    function getCreditLineBalance(address creditLine) external view returns (CreditLineBalance memory);
```
6. Two new hooks are introduced in the liquidity pool contract and triggered during the loan revocation process.
```Solidity
    /// @dev A hook that is triggered by the associated market before the loan revocation.
    /// @param loanId The unique identifier of the loan being revoked.
    function onBeforeLoanRevocation(uint256 loanId) external returns (bool);

    /// @dev A hook that is triggered by the associated market after the loan revocation.
    /// @param loanId The unique identifier of the loan being revoked.
    function onAfterLoanRevocation(uint256 loanId) external returns (bool);
```
7. With the current changes, the logic for managing addons has also changed. When a loan is taken out, the `addonAmount` is no longer transferred to the `addonRecipinet` account. Instead, it remains in the liquidity pool contract and is deducted from the `borrowable` balance of the credit line.

## Storage changes

1. Credit line configuration - the `CreditLineConfig.minRevocationPeriods` field has been added.
2. Credit line configuration - the `CreditLineConfig.maxRevocationPeriods` field has been added.
```Solidity
    uint16 minRevocationPeriods; // The minimum number of periods during which the loan can be revoked.
    uint16 maxRevocationPeriods; // The maximum number of periods during which the loan can be revoked.
```
3. Credit line configuration - the `CreditLineConfig.addonRecipient` field has been removed.
4. Credit line configuration - the `BorrowerConfig.revocationPeriods` field has been added.
```Solidity
    uint16 revocationPeriods; // The number of periods during which the loan can be revoked.
```
5. Loan stored state - the `Loan.State.revocationPeriods` field has been added.
```Solidity
    uint16 revocationPeriods; // The number of periods during which the loan can be revoked.
```
6. Loan stored state - the `Loan.State.addonAmount` field has been added.
``` Solidity
    uint64 addonAmount; // The amount of the loan addon (extra charges or fees).
```
7. Liquidity pool configuration - the credit line balance is now stored as `address -> CreditLineBalance struct` mapping.
```Solidity
    /// @dev A struct that defines the credit line balance.
    struct CreditLineBalance {
        uint64 borrowable; // The amount of tokens that can be borrowed.
        uint64 addons;       // The amount of tokens that are locked as addons.
    }

    /// @dev Mapping of a credit line to its token balance.
    mapping(address => CreditLineBalance) internal _creditLineBalances;
```

## Other changes
1. Contracts minor improvement and refactoring.
2. Tests minor improvement and refactoring.