### PR TITLE
Refactor admin configuration functions to be able to configure batches

### DIFF
--- a/src/common/interfaces/ICreditLineConfigurable.sol
+++ b/src/common/interfaces/ICreditLineConfigurable.sol
@@ -89,10 +89,10 @@ interface ICreditLineConfigurable is ICreditLine {
     //  Functions                                   //
     // -------------------------------------------- //
 
-    /// @dev Configures an account as an admin.
-    /// @param account The address of the account to configure as an admin.
-    /// @param adminStatus True whether the account is an admin.
-    function configureAdmin(address account, bool adminStatus) external;
+    /// @dev Configures a batch of accounts as admins.
+    /// @param accounts The array of addresses of the accounts to configure as an admin.
+    /// @param adminStatuses The array of statuses: true whether the account is an admin.
+    function configureAdmins(address[] memory accounts, bool[] memory adminStatuses) external;
 
     /// @dev Updates the credit line configuration.
     /// @param config The structure containing the credit line configuration.

--- a/src/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/src/common/interfaces/ILiquidityPoolAccountable.sol
@@ -51,10 +51,10 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     //  Functions                                   //
     // -------------------------------------------- //
 
-    /// @dev Configures the admin status for an account.
-    /// @param account The address of the account to configure as an admin.
-    /// @param adminStatus True whether the account is an admin.
-    function configureAdmin(address account, bool adminStatus) external;
+    /// @dev Configures a batch of accounts as admins.
+    /// @param accounts The array of addresses of the accounts to configure as an admin.
+    /// @param adminStatuses The array of statuses: true whether the account is an admin.
+    function configureAdmins(address[] memory accounts, bool[] memory adminStatuses) external;
 
     /// @dev Deposits tokens to the liquidity pool.
     /// @param creditLine The address of the credit line.

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -137,17 +137,13 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
     }
 
     /// @inheritdoc ICreditLineConfigurable
-    function configureAdmin(address account, bool adminStatus) external onlyOwner {
-        if (account == address(0)) {
-            revert Error.ZeroAddress();
+    function configureAdmins(address[] memory accounts, bool[] memory adminStatuses) external onlyOwner {
+        if (accounts.length != adminStatuses.length) {
+            revert Error.ArrayLengthMismatch();
         }
-        if (_admins[account] == adminStatus) {
-            revert Error.AlreadyConfigured();
+        for (uint256 i; i < accounts.length; i++) {
+            _configureAdmin(accounts[i], adminStatuses[i]);
         }
-
-        _admins[account] = adminStatus;
-
-        emit AdminConfigured(account, adminStatus);
     }
 
     /// @inheritdoc ICreditLineConfigurable
@@ -345,6 +341,22 @@ contract CreditLineConfigurable is OwnableUpgradeable, PausableUpgradeable, ICre
     // -------------------------------------------- //
     //  Internal functions                          //
     // -------------------------------------------- //
+
+    /// @dev Updates the configuration of an admin.
+    /// @param account The address of the account to configure admin status.
+    /// @param adminStatus The new adminStatus of the account.
+    function _configureAdmin(address account, bool adminStatus) internal {
+        if (account == address(0)) {
+            revert Error.ZeroAddress();
+        }
+        if (_admins[account] == adminStatus) {
+            revert Error.AlreadyConfigured();
+        }
+
+        _admins[account] = adminStatus;
+
+        emit AdminConfigured(account, adminStatus);
+    }
 
     /// @dev Updates the configuration of a borrower.
     /// @param borrower The address of the borrower to configure.

--- a/src/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/src/liquidity-pools/LiquidityPoolAccountable.sol
@@ -111,17 +111,13 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     }
 
     /// @inheritdoc ILiquidityPoolAccountable
-    function configureAdmin(address account, bool adminStatus) external onlyOwner {
-        if (account == address(0)) {
-            revert Error.ZeroAddress();
+    function configureAdmins(address[] memory accounts, bool[] memory adminStatuses) external onlyOwner {
+        if (accounts.length != adminStatuses.length) {
+            revert Error.ArrayLengthMismatch();
         }
-        if (_admins[account] == adminStatus) {
-            revert Error.AlreadyConfigured();
+        for (uint256 i; i < accounts.length; i++) {
+            _configureAdmin(accounts[i], adminStatuses[i]);
         }
-
-        _admins[account] = adminStatus;
-
-        emit AdminConfigured(account, adminStatus);
     }
 
     /// @inheritdoc ILiquidityPoolAccountable
@@ -291,5 +287,25 @@ contract LiquidityPoolAccountable is OwnableUpgradeable, PausableUpgradeable, IL
     /// @inheritdoc ILiquidityPool
     function kind() external pure returns (uint16) {
         return 1;
+    }
+
+    // -------------------------------------------- //
+    //  Internal functions                          //
+    // -------------------------------------------- //
+
+    /// @dev Updates the configuration of an admin.
+    /// @param account The address of the account to configure admin status.
+    /// @param adminStatus The new adminStatus of the account.
+    function _configureAdmin(address account, bool adminStatus) internal {
+        if (account == address(0)) {
+            revert Error.ZeroAddress();
+        }
+        if (_admins[account] == adminStatus) {
+            revert Error.AlreadyConfigured();
+        }
+
+        _admins[account] = adminStatus;
+
+        emit AdminConfigured(account, adminStatus);
     }
 }

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -46,6 +46,9 @@ contract LendingMarketComplexTest is Test {
     uint256 private constant ZERO_VALUE = 0;
     uint256 private constant PERMISSIBLE_ERROR = 1;
 
+    address[] private admins;
+    bool[] private statuses;
+
     // -------------------------------------------- //
     //  Setup and configuration                     //
     // -------------------------------------------- //
@@ -81,7 +84,11 @@ contract LendingMarketComplexTest is Test {
 
         vm.startPrank(LENDER);
 
-        creditLine.configureAdmin(ADMIN, true);
+        admins.push(ADMIN);
+        statuses.push(true);
+
+        creditLine.configureAdmins(admins, statuses);
+
         lendingMarket.assignLiquidityPoolToCreditLine(address(creditLine), address(liquidityPool));
 
         vm.stopPrank();


### PR DESCRIPTION
With the new functionality, the configuration of admins on both credit line and liquidity pool contracts can now be performed in batches.

### Key changes:
1. Function `configureAdmin()` was renamed into `configureAdmins()`
2. Function `configureAdmins()` now has two parameters: `address[] accounts` and `bool[] statuses`

### Expected behavior:
1. Function `configureAdmins()` will be reverted if arrays length mismatch.
2. Function `configureAdmins()` will be reverted if one of the accounts is zero address.
3. Function `configureAdmins()` will be reverted if one of the accounts is already configured with the same status.

### Tests: 
Test coverage was updated with 100% coverage of the new functionality