### PR TITLE
Round up loan amounts

### DIFF
--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -183,7 +183,7 @@ contract LendingMarket is
         if (borrowAmount == 0) {
             revert Error.InvalidAmount();
         }
-        if (borrowAmount != Round.roundUp(borrowAmount, Constants.ROUND_UP_FACTOR)) {
+        if (borrowAmount != Round.roundUp(borrowAmount, Constants.AMOUNT_ACCURACY_FACTOR)) {
             revert Error.InvalidAmount();
         }
 
@@ -253,17 +253,17 @@ contract LendingMarket is
 
         // Full repayment
         if (repayAmount == type(uint256).max) {
-            outstandingBalance = Round.roundUp(outstandingBalance, Constants.ROUND_UP_FACTOR);
+            outstandingBalance = Round.roundUp(outstandingBalance, Constants.AMOUNT_ACCURACY_FACTOR);
             _repayLoan(loanId, loan, outstandingBalance, outstandingBalance);
             return;
         }
 
-        if (repayAmount != Round.roundUp(repayAmount, Constants.ROUND_UP_FACTOR)) {
+        if (repayAmount != Round.roundUp(repayAmount, Constants.AMOUNT_ACCURACY_FACTOR)) {
             revert Error.InvalidAmount();
         }
 
         if (repayAmount >= outstandingBalance) {
-            if (repayAmount - outstandingBalance > Constants.ROUND_UP_FACTOR) {
+            if (repayAmount - outstandingBalance > Constants.AMOUNT_ACCURACY_FACTOR) {
                 revert Error.InvalidAmount();
             }
             // Full repayment

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -261,13 +261,13 @@ contract LendingMarket is
             revert Error.InvalidAmount();
         }
 
-        if (repayAmount >= outstandingBalance) {
-            if (repayAmount - outstandingBalance > Constants.ACCURACY_FACTOR) {
-                revert Error.InvalidAmount();
-            }
-            // Full repayment
+        // Full repayment
+        if (repayAmount == Round.roundUp(outstandingBalance, Constants.ACCURACY_FACTOR)) {
             _repayLoan(loanId, loan, repayAmount, repayAmount);
-            return;
+            return;}
+
+        if (repayAmount > outstandingBalance) {
+            revert Error.InvalidAmount();
         }
 
         // Partial repayment

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -505,9 +505,8 @@ contract LendingMarket is
         Loan.Preview memory preview;
         Loan.State storage loan = _loans[loanId];
 
-        (preview.accuracyError, preview.periodIndex) = _outstandingBalance(loan, timestamp);
-        preview.outstandingBalance = Round.roundUp(preview.accuracyError, Constants.ACCURACY_FACTOR);
-        preview.accuracyError = preview.outstandingBalance - preview.accuracyError;
+        (preview.trackedBalance, preview.periodIndex) = _outstandingBalance(loan, timestamp);
+        preview.outstandingBalance = Round.roundUp(preview.trackedBalance, Constants.ACCURACY_FACTOR);
 
         return preview;
     }

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -505,8 +505,9 @@ contract LendingMarket is
         Loan.Preview memory preview;
         Loan.State storage loan = _loans[loanId];
 
-        (preview.outstandingBalance, preview.periodIndex) = _outstandingBalance(loan, timestamp);
-        preview.outstandingBalance = Round.roundUp(preview.outstandingBalance, Constants.AMOUNT_ACCURACY_FACTOR);
+        (preview.accuracyError, preview.periodIndex) = _outstandingBalance(loan, timestamp);
+        preview.outstandingBalance = Round.roundUp(preview.accuracyError, Constants.ACCURACY_FACTOR);
+        preview.accuracyError = preview.outstandingBalance - preview.accuracyError;
 
         return preview;
     }

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -210,7 +210,6 @@ contract LendingMarket is
             borrowAmount,
             durationInPeriods
         );
-        terms.addonAmount = Round.roundUp(terms.addonAmount, Constants.ROUND_UP_FACTOR).toUint64();
 
         uint32 blockTimestamp = _blockTimestamp().toUint32();
         uint256 totalBorrowAmount = borrowAmount + terms.addonAmount;

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -506,6 +506,7 @@ contract LendingMarket is
         Loan.State storage loan = _loans[loanId];
 
         (preview.outstandingBalance, preview.periodIndex) = _outstandingBalance(loan, timestamp);
+        preview.outstandingBalance = Round.roundUp(preview.outstandingBalance, Constants.AMOUNT_ACCURACY_FACTOR);
 
         return preview;
     }

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -10,6 +10,7 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/P
 
 import { Loan } from "src/common/libraries/Loan.sol";
 import { Error } from "src/common/libraries/Error.sol";
+import { Round } from "src/common/libraries/Round.sol";
 import { Constants } from "src/common/libraries/Constants.sol";
 import { InterestMath } from "src/common/libraries/InterestMath.sol";
 import { SafeCast } from "src/common/libraries/SafeCast.sol";
@@ -182,6 +183,9 @@ contract LendingMarket is
         if (borrowAmount == 0) {
             revert Error.InvalidAmount();
         }
+        if (borrowAmount != Round.roundUp(borrowAmount, Constants.ROUND_UP_FACTOR)) {
+            revert Error.InvalidAmount();
+        }
 
         address lender = _creditLineLenders[creditLine];
         if (lender == address(0)) {
@@ -206,6 +210,7 @@ contract LendingMarket is
             borrowAmount,
             durationInPeriods
         );
+        terms.addonAmount = Round.roundUp(terms.addonAmount, Constants.ROUND_UP_FACTOR).toUint64();
 
         uint32 blockTimestamp = _blockTimestamp().toUint32();
         uint256 totalBorrowAmount = borrowAmount + terms.addonAmount;
@@ -244,28 +249,50 @@ contract LendingMarket is
         }
 
         Loan.State storage loan = _loans[loanId];
+        (uint256 outstandingBalance,) = _outstandingBalance(loan, _blockTimestamp());
 
+        // Full repayment
+        if (repayAmount == type(uint256).max) {
+            outstandingBalance = Round.roundUp(outstandingBalance, Constants.ROUND_UP_FACTOR);
+            _repayLoan(loanId, loan, outstandingBalance, outstandingBalance);
+            return;
+        }
+
+        if (repayAmount != Round.roundUp(repayAmount, Constants.ROUND_UP_FACTOR)) {
+            revert Error.InvalidAmount();
+        }
+
+        if (repayAmount >= outstandingBalance) {
+            if (repayAmount - outstandingBalance > Constants.ROUND_UP_FACTOR) {
+                revert Error.InvalidAmount();
+            }
+            // Full repayment
+            _repayLoan(loanId, loan, repayAmount, repayAmount);
+            return;
+        }
+
+        // Partial repayment
+        _repayLoan(loanId, loan, repayAmount, outstandingBalance);
+    }
+
+    /// @dev Updates the loan state and makes the necessary transfers when repaying a loan.
+    /// @param loanId The unique identifier of the loan to repay.
+    /// @param loan The storage state of the loan to update.
+    /// @param repayAmount The amount to repay.
+    /// @param outstandingBalance The outstanding balance of the loan.
+    function _repayLoan(uint256 loanId, Loan.State storage loan, uint256 repayAmount, uint256 outstandingBalance) internal {
         if (loan.treasury.code.length == 0) {
             // TBD Add support for EOA liquidity pools.
             revert Error.NotImplemented();
         }
 
-        (uint256 outstandingBalance,) = _outstandingBalance(loan, _blockTimestamp());
-
-        if (repayAmount == type(uint256).max) {
-            repayAmount = outstandingBalance;
-        } else if (repayAmount > outstandingBalance) {
-            revert Error.InvalidAmount();
-        }
-
         bool autoRepayment = loan.treasury == msg.sender;
-
+        address payer = autoRepayment ? loan.borrower : msg.sender;
         if (autoRepayment && !Constants.AUTO_REPAYMENT_ENABLED) {
             revert AutoRepaymentNotAllowed();
         }
 
         outstandingBalance -= repayAmount;
-        address payer = autoRepayment ? loan.borrower : msg.sender;
 
         ILiquidityPool(loan.treasury).onBeforeLoanPayment(loanId, repayAmount);
 
@@ -426,6 +453,9 @@ contract LendingMarket is
         }
     }
 
+    /// @dev Updates the loan state and makes the necessary transfers when revoking a loan.
+    /// @param loanId The unique identifier of the loan to revoke.
+    /// @param loan The storage state of the loan to update.
     function _revokeLoan(uint256 loanId, Loan.State storage loan) internal {
         ILiquidityPool(loan.treasury).onBeforeLoanRevocation(loanId);
 

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -248,7 +248,7 @@ contract LendingMarket is
         }
 
         Loan.State storage loan = _loans[loanId];
-        (uint256 outstandingBalance,) = _outstandingBalance(loan, _blockTimestamp());
+        (uint256 outstandingBalance, ) = _outstandingBalance(loan, _blockTimestamp());
 
         // Full repayment
         if (repayAmount == type(uint256).max) {
@@ -264,7 +264,8 @@ contract LendingMarket is
         // Full repayment
         if (repayAmount == Round.roundUp(outstandingBalance, Constants.ACCURACY_FACTOR)) {
             _repayLoan(loanId, loan, repayAmount, repayAmount);
-            return;}
+            return;
+        }
 
         if (repayAmount > outstandingBalance) {
             revert Error.InvalidAmount();
@@ -279,7 +280,12 @@ contract LendingMarket is
     /// @param loan The storage state of the loan to update.
     /// @param repayAmount The amount to repay.
     /// @param outstandingBalance The outstanding balance of the loan.
-    function _repayLoan(uint256 loanId, Loan.State storage loan, uint256 repayAmount, uint256 outstandingBalance) internal {
+    function _repayLoan(
+        uint256 loanId,
+        Loan.State storage loan,
+        uint256 repayAmount,
+        uint256 outstandingBalance
+    ) internal {
         if (loan.treasury.code.length == 0) {
             // TBD Add support for EOA liquidity pools.
             revert Error.NotImplemented();

--- a/src/LendingMarket.sol
+++ b/src/LendingMarket.sol
@@ -183,7 +183,7 @@ contract LendingMarket is
         if (borrowAmount == 0) {
             revert Error.InvalidAmount();
         }
-        if (borrowAmount != Round.roundUp(borrowAmount, Constants.AMOUNT_ACCURACY_FACTOR)) {
+        if (borrowAmount != Round.roundUp(borrowAmount, Constants.ACCURACY_FACTOR)) {
             revert Error.InvalidAmount();
         }
 
@@ -252,17 +252,17 @@ contract LendingMarket is
 
         // Full repayment
         if (repayAmount == type(uint256).max) {
-            outstandingBalance = Round.roundUp(outstandingBalance, Constants.AMOUNT_ACCURACY_FACTOR);
+            outstandingBalance = Round.roundUp(outstandingBalance, Constants.ACCURACY_FACTOR);
             _repayLoan(loanId, loan, outstandingBalance, outstandingBalance);
             return;
         }
 
-        if (repayAmount != Round.roundUp(repayAmount, Constants.AMOUNT_ACCURACY_FACTOR)) {
+        if (repayAmount != Round.roundUp(repayAmount, Constants.ACCURACY_FACTOR)) {
             revert Error.InvalidAmount();
         }
 
         if (repayAmount >= outstandingBalance) {
-            if (repayAmount - outstandingBalance > Constants.AMOUNT_ACCURACY_FACTOR) {
+            if (repayAmount - outstandingBalance > Constants.ACCURACY_FACTOR) {
                 revert Error.InvalidAmount();
             }
             // Full repayment

--- a/src/common/libraries/Constants.sol
+++ b/src/common/libraries/Constants.sol
@@ -21,6 +21,6 @@ library Constants {
     /// @dev The flag that indicates whether the auto repayment is enabled.
     bool internal constant AUTO_REPAYMENT_ENABLED = true;
 
-    /// @dev The factor used for rounding up the loan amounts.
-    uint256 internal constant ROUND_UP_FACTOR = 10000;
+    /// @dev The accuracy factor used for loan amounts calculations.
+    uint256 internal constant AMOUNT_ACCURACY_FACTOR = 10000;
 }

--- a/src/common/libraries/Constants.sol
+++ b/src/common/libraries/Constants.sol
@@ -21,6 +21,6 @@ library Constants {
     /// @dev The flag that indicates whether the auto repayment is enabled.
     bool internal constant AUTO_REPAYMENT_ENABLED = true;
 
-    /// @dev The accuracy factor used for loan amounts calculations.
+    /// @dev The accuracy factor used for loan amounts calculation.
     uint256 internal constant AMOUNT_ACCURACY_FACTOR = 10000;
 }

--- a/src/common/libraries/Constants.sol
+++ b/src/common/libraries/Constants.sol
@@ -20,4 +20,7 @@ library Constants {
 
     /// @dev The flag that indicates whether the auto repayment is enabled.
     bool internal constant AUTO_REPAYMENT_ENABLED = true;
+
+    /// @dev The factor used for rounding up the loan amounts.
+    uint256 internal constant ROUND_UP_FACTOR = 10000;
 }

--- a/src/common/libraries/Constants.sol
+++ b/src/common/libraries/Constants.sol
@@ -22,5 +22,5 @@ library Constants {
     bool internal constant AUTO_REPAYMENT_ENABLED = true;
 
     /// @dev The accuracy factor used for loan amounts calculation.
-    uint256 internal constant AMOUNT_ACCURACY_FACTOR = 10000;
+    uint64 internal constant ACCURACY_FACTOR = 10000;
 }

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -48,7 +48,7 @@ library Loan {
     /// @dev A struct that defines the preview of the loan.
     struct Preview {
         uint256 periodIndex;        // The period index that matches the preview timestamp.
+        uint256 trackedBalance;     // The tracked balance of the loan at the previewed period.
         uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
-        uint256 accuracyError;      // The accuracy error of the previewed outstanding balance.
     }
 }

--- a/src/common/libraries/Loan.sol
+++ b/src/common/libraries/Loan.sol
@@ -49,5 +49,6 @@ library Loan {
     struct Preview {
         uint256 periodIndex;        // The period index that matches the preview timestamp.
         uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
+        uint256 accuracyError;      // The accuracy error of the previewed outstanding balance.
     }
 }

--- a/src/common/libraries/Round.sol
+++ b/src/common/libraries/Round.sol
@@ -6,17 +6,17 @@ pragma solidity 0.8.24;
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Defines upward and downward rounding functions.
 library Round {
-    /// @dev Rounds up a value to the nearest multiple of a precision.
+    /// @dev Rounds up a value to the nearest multiple of an accuracy.
     /// @param value The value to be rounded.
-    /// @param precision The precision to round to.
-    function roundUp(uint256 value, uint256 precision) internal pure returns (uint256) {
-        return (value + precision - 1) / precision * precision;
+    /// @param accuracy The accuracy to which the value should be rounded.
+    function roundUp(uint256 value, uint256 accuracy) internal pure returns (uint256) {
+        return (value + accuracy - 1) / accuracy * accuracy;
     }
 
-    /// @dev Rounds down a value to the nearest multiple of a precision.
+    /// @dev Rounds down a value to the nearest multiple of an accuracy.
     /// @param value The value to be rounded.
-    /// @param precision The precision to round to.
-    function roundDown(uint256 value, uint256 precision) internal pure returns (uint256) {
-        return value / precision * precision;
+    /// @param accuracy The accuracy to which the value should be rounded.
+    function roundDown(uint256 value, uint256 accuracy) internal pure returns (uint256) {
+        return value / accuracy * accuracy;
     }
 }

--- a/src/common/libraries/Round.sol
+++ b/src/common/libraries/Round.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+/// @title Round library
+/// @author CloudWalk Inc. (See https://cloudwalk.io)
+/// @dev Defines upward and downward rounding functions.
+library Round {
+    /// @dev Rounds up a value to the nearest multiple of a precision.
+    /// @param value The value to be rounded.
+    /// @param precision The precision to round to.
+    function roundUp(uint256 value, uint256 precision) internal pure returns (uint256) {
+        return (value + precision - 1) / precision * precision;
+    }
+
+    /// @dev Rounds down a value to the nearest multiple of a precision.
+    /// @param value The value to be rounded.
+    /// @param precision The precision to round to.
+    function roundDown(uint256 value, uint256 precision) internal pure returns (uint256) {
+        return value / precision * precision;
+    }
+}

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -6,6 +6,7 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/P
 
 import { Loan } from "../common/libraries/Loan.sol";
 import { Error } from "../common/libraries/Error.sol";
+import { Round } from "../common/libraries/Round.sol";
 import { SafeCast } from "../common/libraries/SafeCast.sol";
 import { Constants } from "../common/libraries/Constants.sol";
 
@@ -271,13 +272,13 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         terms.durationInPeriods = durationInPeriods.toUint32();
         terms.interestRatePrimary = borrowerConfig.interestRatePrimary;
         terms.interestRateSecondary = borrowerConfig.interestRateSecondary;
-        terms.addonAmount = calculateAddonAmount(
+        terms.addonAmount = Round.roundUp(calculateAddonAmount(
             borrowAmount,
             durationInPeriods,
             borrowerConfig.addonFixedRate,
             borrowerConfig.addonPeriodRate,
             Constants.INTEREST_RATE_FACTOR
-        ).toUint64();
+        ), Constants.AMOUNT_ACCURACY_FACTOR).toUint64();
     }
 
     /// @inheritdoc ICreditLineConfigurable

--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -278,7 +278,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
             borrowerConfig.addonFixedRate,
             borrowerConfig.addonPeriodRate,
             Constants.INTEREST_RATE_FACTOR
-        ), Constants.AMOUNT_ACCURACY_FACTOR).toUint64();
+        ), Constants.ACCURACY_FACTOR).toUint64();
     }
 
     /// @inheritdoc ICreditLineConfigurable

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -212,28 +212,30 @@ contract LendingMarketComplexTest is Test {
             skip(Constants.PERIOD_IN_SECONDS * scenario.iterationStep);
 
             Loan.Preview memory previewBefore = lendingMarket.getLoanPreview(loanId, 0);
+            uint256 outstandingBalanceBefore = previewBefore.outstandingBalance + previewBefore.accuracyError;
 
             if (scenario.repaymentAmounts[i] != 0) {
                 lendingMarket.repayLoan(loanId, scenario.repaymentAmounts[i]);
             }
 
             Loan.Preview memory previewAfter = lendingMarket.getLoanPreview(loanId, 0);
+            uint256 outstandingBalanceAfter = previewAfter.outstandingBalance + previewAfter.accuracyError;
 
-            uint256 difference = diff(previewBefore.outstandingBalance, scenario.outstandingBalancesBeforeRepayment[i]);
+            uint256 difference = diff(outstandingBalanceBefore, scenario.outstandingBalancesBeforeRepayment[i]);
             uint256 precision = difference * scenario.precisionFactor / scenario.outstandingBalancesBeforeRepayment[i];
 
             if (precision > scenario.precisionMinimum) {
                 console.log("------------------ Precision error ------------------");
                 console.log("Index: ", i);
                 console.log("Expected balance before repayment: ", scenario.outstandingBalancesBeforeRepayment[i]);
-                console.log("Actual balance before repayment: ", previewBefore.outstandingBalance);
+                console.log("Actual balance before repayment: ", outstandingBalanceBefore);
                 console.log("Payment amount: ", scenario.repaymentAmounts[i]);
                 console.log("Difference: ", difference);
                 revert("Precision error");
             }
 
             require(
-                previewAfter.outstandingBalance == previewBefore.outstandingBalance - scenario.repaymentAmounts[i],
+                outstandingBalanceAfter == outstandingBalanceBefore - scenario.repaymentAmounts[i],
                 "Outstanding balance mismatch after repayment"
             );
         }

--- a/test/complex/LendingMarket.complex.t.sol
+++ b/test/complex/LendingMarket.complex.t.sol
@@ -212,30 +212,28 @@ contract LendingMarketComplexTest is Test {
             skip(Constants.PERIOD_IN_SECONDS * scenario.iterationStep);
 
             Loan.Preview memory previewBefore = lendingMarket.getLoanPreview(loanId, 0);
-            uint256 outstandingBalanceBefore = previewBefore.outstandingBalance + previewBefore.accuracyError;
 
             if (scenario.repaymentAmounts[i] != 0) {
                 lendingMarket.repayLoan(loanId, scenario.repaymentAmounts[i]);
             }
 
             Loan.Preview memory previewAfter = lendingMarket.getLoanPreview(loanId, 0);
-            uint256 outstandingBalanceAfter = previewAfter.outstandingBalance + previewAfter.accuracyError;
 
-            uint256 difference = diff(outstandingBalanceBefore, scenario.outstandingBalancesBeforeRepayment[i]);
+            uint256 difference = diff(previewBefore.trackedBalance, scenario.outstandingBalancesBeforeRepayment[i]);
             uint256 precision = difference * scenario.precisionFactor / scenario.outstandingBalancesBeforeRepayment[i];
 
             if (precision > scenario.precisionMinimum) {
                 console.log("------------------ Precision error ------------------");
                 console.log("Index: ", i);
                 console.log("Expected balance before repayment: ", scenario.outstandingBalancesBeforeRepayment[i]);
-                console.log("Actual balance before repayment: ", outstandingBalanceBefore);
+                console.log("Actual balance before repayment: ", previewBefore.trackedBalance);
                 console.log("Payment amount: ", scenario.repaymentAmounts[i]);
                 console.log("Difference: ", difference);
                 revert("Precision error");
             }
 
             require(
-                outstandingBalanceAfter == outstandingBalanceBefore - scenario.repaymentAmounts[i],
+                previewAfter.trackedBalance == previewBefore.trackedBalance - scenario.repaymentAmounts[i],
                 "Outstanding balance mismatch after repayment"
             );
         }

--- a/test/other/Round.t.sol
+++ b/test/other/Round.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import { Test } from "forge-std/Test.sol";
+import { Round } from "src/common/libraries/Round.sol";
+
+/// @title RoundTest contract
+/// @author CloudWalk Inc. (See https://cloudwalk.io)
+/// @dev Contains tests for the `Round` library.
+contract RoundTest is Test {
+    function test_roundUp() public {
+        uint256 precision = 10000;
+        uint256 inputValue = 10000;
+        uint256 outputValue = 10000;
+        assertEq(Round.roundUp(inputValue, precision), precision);
+
+        inputValue = 10001;
+        outputValue = 20000;
+        assertEq(Round.roundUp(inputValue, precision), outputValue);
+
+        inputValue = 9999;
+        outputValue = 10000;
+        assertEq(Round.roundUp(inputValue, precision), outputValue);
+    }
+
+    function test_roundDown() public {
+        uint256 precision = 10000;
+        uint256 inputValue = 10000;
+        uint256 outputValue = 10000;
+        assertEq(Round.roundDown(inputValue, precision), outputValue);
+
+        inputValue = 10001;
+        outputValue = 10000;
+        assertEq(Round.roundDown(inputValue, precision), outputValue);
+
+        inputValue = 9999;
+        outputValue = 0;
+        assertEq(Round.roundDown(inputValue, precision), outputValue);
+    }
+}


### PR DESCRIPTION
## Description 

The new concept of "loan amount accuracy" has been introduced to round loan amounts when working with protocol.

## Main changes
1. A new protocol-level constant `ACCURACY_FACTOR` has been introduced. This constant defines the accuracy factor used to calculate loan amounts and prevent user input when taking and repaying loans.
2. The amount parameters passed to the `takeLoan` and `repayLoan` functions must be rounded according to the protocol-level accuracy defined by the `ACCURACY_FACTOR` constant. Otherwise, those functions will revert.
3. The `addonAmount` value returned from the `determineLoanTerms` function is rounded up to the protocol-level accuracy.
4. The `outstandingBalance` value returned from the `getLoanPreview` function is rounded up to the protocol-level accuracy. 
5. The `trackedBalance` field has been added to the `Loan.Preview` structure, which represents an unrounded outstanding loan balance. 

## Changes in code declaration

```Solidity
/// @dev The accuracy factor used for loan amounts calculation.
uint256 internal constant ACCURACY_FACTOR = 10000;

/// @dev A struct that defines the preview of the loan.
struct Preview {
    uint256 periodIndex;        // The period index that matches the preview timestamp.
    uint256 trackedBalance;     // The tracked balance of the loan at the previewed period.
    uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
}
```

## Test coverage
New functionality was partially covered with tests. Work in progress.