### PR TITLE
Don't count `addonAmount` against the `maxBorrowAmount`

### DIFF
--- a/src/credit-lines/CreditLineConfigurable.sol
+++ b/src/credit-lines/CreditLineConfigurable.sol
@@ -223,7 +223,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         if (borrowerConfig.borrowPolicy == BorrowPolicy.Keep) {
             // Do nothing to the borrower's max borrow amount configuration
         } else if (borrowerConfig.borrowPolicy == BorrowPolicy.Decrease || borrowerConfig.borrowPolicy == BorrowPolicy.Iterate) {
-            borrowerConfig.maxBorrowAmount -= loan.borrowAmount + loan.addonAmount;
+            borrowerConfig.maxBorrowAmount -= loan.borrowAmount;
         } else { // borrowerConfig.borrowPolicy == BorrowPolicy.Reset
             borrowerConfig.maxBorrowAmount = 0;
         }
@@ -238,7 +238,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         if (loan.trackedBalance == 0) {
             BorrowerConfig storage borrowerConfig = _borrowers[loan.borrower];
             if (borrowerConfig.borrowPolicy == BorrowPolicy.Iterate) {
-                borrowerConfig.maxBorrowAmount += loan.borrowAmount + loan.addonAmount;
+                borrowerConfig.maxBorrowAmount += loan.borrowAmount;
             }
         }
 
@@ -249,7 +249,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
         BorrowerConfig storage borrowerConfig = _borrowers[loan.borrower];
         if (borrowerConfig.borrowPolicy == BorrowPolicy.Iterate) {
-            borrowerConfig.maxBorrowAmount += loan.borrowAmount + loan.addonAmount;
+            borrowerConfig.maxBorrowAmount += loan.borrowAmount;
         }
 
         return true;

--- a/test/credit-lines/CreditLineConfigurable.t.sol
+++ b/test/credit-lines/CreditLineConfigurable.t.sol
@@ -791,7 +791,7 @@ contract CreditLineConfigurableTest is Test {
 
         assertEq(
             creditLine.getBorrowerConfiguration(BORROWER_1).maxBorrowAmount,
-            config.maxBorrowAmount - (config.minBorrowAmount + addonAmount)
+            config.maxBorrowAmount - config.minBorrowAmount
         );
     }
 
@@ -818,7 +818,7 @@ contract CreditLineConfigurableTest is Test {
 
         assertEq(
             creditLine.getBorrowerConfiguration(BORROWER_1).maxBorrowAmount,
-            config.maxBorrowAmount - (config.minBorrowAmount + addonAmount)
+            config.maxBorrowAmount - config.minBorrowAmount
         );
     }
 
@@ -884,7 +884,7 @@ contract CreditLineConfigurableTest is Test {
 
         assertEq(
             creditLine.getBorrowerConfiguration(BORROWER_1).maxBorrowAmount,
-            config.maxBorrowAmount - (config.minBorrowAmount + addonAmount)
+            config.maxBorrowAmount - config.minBorrowAmount
         );
 
         // Partial repayment
@@ -898,7 +898,7 @@ contract CreditLineConfigurableTest is Test {
 
         assertEq(
             creditLine.getBorrowerConfiguration(BORROWER_1).maxBorrowAmount,
-            config.maxBorrowAmount - (config.minBorrowAmount + addonAmount)
+            config.maxBorrowAmount - config.minBorrowAmount
         );
 
         // Full repayment
@@ -970,7 +970,7 @@ contract CreditLineConfigurableTest is Test {
 
         assertEq(
             creditLine.getBorrowerConfiguration(BORROWER_1).maxBorrowAmount,
-            config.maxBorrowAmount - (config.minBorrowAmount + addonAmount)
+            config.maxBorrowAmount - config.minBorrowAmount
         );
 
         vm.prank(address(lendingMarket));


### PR DESCRIPTION
## Description

With the current changes, we stopped considering the `addonAmount` when working with the borrower's `maxBorrowAmount` configuration on the credit line contract.  

### Test coverage
New functionality was covered with tests.